### PR TITLE
change full_name -> name

### DIFF
--- a/gdcdatamodel/avro/schemata/node_properties.avsc
+++ b/gdcdatamodel/avro/schemata/node_properties.avsc
@@ -268,7 +268,7 @@
     "namespace": "edu.uchicago.cdis",
     "fields": [
       {
-        "name": "full_name",
+        "name": "name",
         "type": "string",
         "doc": "TOREVIEW: display name for the project"
       }
@@ -280,7 +280,7 @@
     "namespace": "edu.uchicago.cdis",
     "fields": [
       {
-        "name": "full_name",
+        "name": "name",
         "type": "string",
         "doc": "TOREVIEW: display name for the project"
       }


### PR DESCRIPTION
change `full_name` to `name` in projects and programs, for consistency with the other singleton nodes we have (which all just have a name property).

r? @allisonheath
