### PR TITLE
add an uploaded state for files

### DIFF
--- a/gdcdatamodel/avro/schemata/field_types.avsc
+++ b/gdcdatamodel/avro/schemata/field_types.avsc
@@ -117,6 +117,7 @@
     "symbols": [
       "submitted",
       "uploading",
+      "uploaded",
       "generating",
       "validating",
       "invalid",


### PR DESCRIPTION
r? @allisonheath 

I realized an `uploaded` state is necessary, since during the import process I want a workflow something like:

1) set file to `submitted`
2) set state to `uploading`, attempt to upload: if fail -> set to `submitted`, if succeed, set to `uploaded`
3) set state to `validating`, start md5ing: if fail -> set to `uploaded`, if succeed set to -> `live`

right now this doesn't work because there's no `uploaded` state 
