### PR TITLE
allow other as a race

### DIFF
--- a/gdcdatamodel/avro/schemata/field_types.avsc
+++ b/gdcdatamodel/avro/schemata/field_types.avsc
@@ -220,7 +220,8 @@
       "american indian or alaska native",
       "black or african american",
       "asian",
-      "native hawaiian or other pacific islander"
+      "native hawaiian or other pacific islander",
+      "other"
     ],
     "type": "enum",
     "doc": "TOREVIEW: Allowed races"


### PR DESCRIPTION
for target clinicals, which have other in some places; we don't seem to have anything that matches (we have `not reported` but that is not the same thing)

cc @allisonheath @majensen 
