### PR TITLE
add reporting model from API

### DIFF
--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -2,5 +2,6 @@ from psqlgraph import Node, Edge
 from utils import validate
 from edges import *
 from nodes import *
+from misc import *
 from sqlalchemy.orm import configure_mappers
 configure_mappers()

--- a/gdcdatamodel/models/misc.py
+++ b/gdcdatamodel/models/misc.py
@@ -1,0 +1,16 @@
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, String, Integer, Text, DateTime, BigInteger
+
+
+Base = declarative_base()
+
+
+class FileReport(Base):
+    __tablename__ = 'filereport'
+    id = Column('id', Integer, primary_key=True)
+    node_id = Column('node_id', Text, index=True)
+    ip = Column('ip', String)
+    country_code = Column('country_code', String, index=True)
+    timestamp = Column('timestamp', DateTime, server_default="now()")
+    streamed_bytes = Column('streamed_bytes', BigInteger)
+    username = Column('username', String, index=True)


### PR DESCRIPTION
This model is currently in gdcapi code and is used to log all download requests. Moving it here is necessary so that zugs can use to generate the elasicsearch index based on those logs.
