### PR TITLE
Remove the nonnull annotation note constraint

### DIFF
--- a/gdcdatamodel/models/nodes/annotation.py
+++ b/gdcdatamodel/models/nodes/annotation.py
@@ -11,7 +11,6 @@ class Annotation(Node):
         'creator',
         'created_datetime',
         'status',
-        'notes'
     ]
 
     @pg_property(str)


### PR DESCRIPTION
Allow annotation notes to be null to allow for annotations without notes.
