### PR TITLE
add access to mapping for related_files

### DIFF
--- a/gdcdatamodel/mappings.py
+++ b/gdcdatamodel/mappings.py
@@ -171,6 +171,7 @@ def get_file_es_mapping(include_case=True):
     related_files.properties.type = STRING
     related_files.properties.data_type = STRING
     related_files.properties.data_subtype = STRING
+    related_files.properties.access = STRING
     patch_file_timestamps(related_files)
     files.properties.related_files = related_files
 


### PR DESCRIPTION
This adds an "access" field to the es mapping for related_files, which is a prerequisite for https://github.com/NCI-GDC/zugs/pull/159.
