### PR TITLE
Feat/es index analyzers

### DIFF
--- a/gdcdatamodel/mappings.py
+++ b/gdcdatamodel/mappings.py
@@ -25,28 +25,34 @@ MULTIFIELDS = {
 
 
 def index_settings():
-    return {"settings":
-            {"analysis":
-             {"analyzer":
-              {"id_search":
-               {"tokenizer": "whitespace",
-                "filter": ["lowercase"],
-                "type": "custom"},
-               "id_index": {
-                   "tokenizer": "whitespace",
-                   "filter": [
-                       "lowercase",
-                       "edge_ngram"
-                   ],
-                   "type": "custom"
-               }},
-              "filter": {
-                  "edge_ngram": {
-                      "side": "front",
-                      "max_gram": 20,
-                      "min_gram": 2,
-                      "type": "edge_ngram"
-                  }}}}}
+    return {"settings": {"analysis": {"analyzer": {
+        "id_search": {
+            "tokenizer": "whitespace",
+            "filter": ["lowercase"],
+            "type": "custom"},
+        "project_id_search": {
+            "tokenizer": "whitespace",
+            "filter": ["lowercase", "project_delimiter"],
+            "type": "custom"},
+        "id_index": {
+            "tokenizer": "whitespace",
+            "filter": ["lowercase", "edge_ngram"],
+            "type": "custom"}
+    }, "filter": {
+        "edge_ngram": {
+            "side": "front",
+            "max_gram": 20,
+            "min_gram": 2,
+            "type": "edge_ngram"},
+        "project_delimiter": {
+            "type": "word_delimiter",
+            "catenate_numbers": False,
+            "generate_number_parts": False,
+            "split_on_case_change": False,
+            "stem_english_possessive": False,
+            "split_on_numerics": False,
+            "preserve_original": True}
+    }}}}
 
 
 def _get_header(source):

--- a/gdcdatamodel/mappings.py
+++ b/gdcdatamodel/mappings.py
@@ -19,8 +19,8 @@ TOP_LEVEL_IDS = ['sample', 'portion', 'analyte', 'aliquot', 'slide']
 MULTIFIELDS = {
     'project': ['code', 'disease_type', 'name', 'primary_site'],
     'annotation': ['annotation_id', 'entity_id'],
-    'files': ['file_id', 'file_name'],
-    'case': ['case_id', 'submitter_id'],
+    'files': ['file_name'],
+    'case': ['submitter_id'],
 }
 
 
@@ -294,6 +294,7 @@ def get_project_es_mapping():
     # Patch project
     patch_project(project.properties)
     project.properties.update(multifield('project_id'))
+    project.properties.project_id.search_analyzer = "project_delimeter"
 
     # Summary
     summary = project.properties.summary.properties


### PR DESCRIPTION
This branch:

- Removes multifield from file_id and case_id (UUID fields)
- Changes project_id.analyzer to new search analyzer w/ custom
  word_delimiter

@shanewilson @cy: I am unfamiliar with elasticsearch analyzers and am not sure that this is remotely close to being correct.  I have yet to test this config on dev for the next esbuild.