### PR TITLE
feat(graph): compute traversals

### DIFF
--- a/gdcdatamodel/__init__.py
+++ b/gdcdatamodel/__init__.py
@@ -1,1 +1,1 @@
-from gdcdatamodel import *
+from mappings import *

--- a/gdcdatamodel/gdcdatamodel.py
+++ b/gdcdatamodel/gdcdatamodel.py
@@ -1,1 +1,0 @@
-from mappings import *

--- a/gdcdatamodel/graph.py
+++ b/gdcdatamodel/graph.py
@@ -1,0 +1,33 @@
+import models
+
+from psqlgraph import Node, Edge
+
+traversals = {}
+terminal_nodes = ['annotation', 'center', 'archive', 'tissue_source_site']
+
+
+def walk_graph(root, node, visited, path):
+
+    for edge in Edge._get_edges_with_src(node.__name__):
+        neighbor = [n for n in Node.get_subclasses()
+                    if n.__name__ == edge.__dst_class__][0]
+        if neighbor and neighbor not in visited\
+           and neighbor != node and neighbor.label not in terminal_nodes:
+            walk_graph(
+                root, neighbor, visited+[node], path+[edge.__src_dst_assoc__])
+
+    for edge in Edge._get_edges_with_dst(node.__name__):
+        neighbor = [n for n in Node.get_subclasses()
+                    if n.__name__ == edge.__src_class__][0]
+        if neighbor and neighbor not in visited\
+           and neighbor != node and neighbor.label not in terminal_nodes:
+            walk_graph(
+                root, neighbor, visited+[node], path+[edge.__dst_src_assoc__])
+
+    traversals[root][node.label] = traversals[root].get(node.label) or set()
+    traversals[root][node.label].add('.'.join(path))
+
+
+for node in Node.get_subclasses():
+    traversals[node.label] = {}
+    walk_graph(node.label, node, [node], [])


### PR DESCRIPTION
This module computes the possible paths between any two node types given any set of Node subclasses.  

A heuristic limitation has been added to prevent traversals through heavily trafficked nodes (like center) and spurious paths.
