### PR TITLE
fix(validator): clean up unique key validator

### DIFF
--- a/gdcdatamodel/validators/graph_validators.py
+++ b/gdcdatamodel/validators/graph_validators.py
@@ -110,11 +110,9 @@ class GDCUniqueKeysValidator(object):
         node = entity.node
         for keys in schema['uniqueKeys']:
             props = {}
-            if keys in [['id'], ['project_id', 'alias']]:
+            if keys == ['id']:
                 # uuid uniqueness should be checked during node creation
-                # by psqlgraph,
-                # [project_id, alias] need to be checked after we
-                # decide on where to put project_id
+                # by psqlgraph
                 continue
             for key in keys:
                 prop = schema['properties'][key].get('systemAlias')

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -245,3 +245,26 @@ class TestValidators(unittest.TestCase):
             self.entities[0].node = node
             self.graph_validator.record_errors(g, self.entities)
             self.assertEquals(['name'], self.entities[0].errors[0]['keys'])
+
+
+    def test_graph_validator_with_existing_submiter_id(self):
+        with g.session_scope() as session:
+            analyte = self.create_node(
+                    {'type': 'analyte',
+                     'props': {'submitter_id': 'test',
+                               'analyte_type_id': 'D',
+                               'analyte_type': 'DNA'},
+                     'edges': {}}, session)
+
+            node = self.create_node({'type': 'aliquot',
+                                     'props': {'submitter_id': 'test', 'project_id': 'test'},
+                                     'edges': {'analytes': [analyte.node_id]}},
+                                    session)
+            node = self.create_node({'type': 'aliquot',
+                                     'props': {'submitter_id': 'test', 'project_id': 'test'},
+                                     'edges': {'analytes': [analyte.node_id]}},
+                                    session)
+            self.update_schema('aliquot', 'uniqueKeys', [['submitter_id', 'project_id']])
+            self.entities[0].node = node
+            self.graph_validator.record_errors(g, self.entities)
+            self.assertEquals(['project_id', 'submitter_id'], self.entities[0].errors[0]['keys'])


### PR DESCRIPTION
The UniqueKey validator was created when we are still using 'alias', just delete this exceptional case and add one test for submitter id uniqueness checking.
r? @millerjs 
