### PR TITLE
feat(gdc_pg_admin): update pg administration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ addons:
   postgresql: '9.4'
 before_script:
     - yes | python setup.py install
-    - python bin/setup_psqlgraph.py
+    - python bin/destroy_and_setup_psqlgraph.py
     - pip freeze
 script: "nosetests -v"

--- a/bin/destroy_and_setup_psqlgraph.py
+++ b/bin/destroy_and_setup_psqlgraph.py
@@ -113,6 +113,11 @@ if __name__ == '__main__':
                         default=False, help="do not create user")
 
     args = parser.parse_args()
+
+    assert args.host == 'localhost', (
+        "Refusing to run on a host that is not localhost! "
+        "(This script deletes all the data in the database!)")
+
     setup_database(args.user, args.password, args.database,
                    no_drop=args.no_drop, no_user=args.no_user)
     create_tables(args.host, args.user, args.password, args.database)

--- a/gdcdatamodel/gdc_postgres_admin.py
+++ b/gdcdatamodel/gdc_postgres_admin.py
@@ -1,0 +1,444 @@
+# -*- coding: utf-8 -*-
+"""
+gdcdatamodel.gdc_postgres_admin
+----------------------------------
+
+Module for stateful management of a GDC PostgreSQL installation.
+"""
+
+import argparse
+import logging
+import random
+import sqlalchemy as sa
+import time
+
+from collections import namedtuple
+from sqlalchemy import create_engine
+from sqlalchemy.exc import OperationalError
+
+#: Required but 'unused' import to register GDC models
+from . import models  # noqa
+
+from psqlgraph import (
+    create_all,
+    Node,
+    Edge,
+)
+
+logging.basicConfig()
+logger = logging.getLogger("gdc_postgres_admin")
+logger.setLevel(logging.INFO)
+
+name_root = "table_creator_"
+app_name = "{}{}".format(name_root, random.randint(1000, 9999))
+no_kill_list = []
+BlockingQueryResult = namedtuple('BlockingQueryResult', [
+    'blocked_appname',
+    'blocked_pid',
+    'blocking_appname',
+    'blocking_pid',
+    'blocking_statement',
+])
+
+
+# See https://wiki.postgresql.org/wiki/Lock_Monitoring
+BLOCKING_SQL = """
+
+SELECT
+    blocked_activity.application_name  AS blocked_appname,
+    blocked_locks.pid                  AS blocked_pid,
+
+    blocking_activity.application_name AS blocking_appname,
+    blocking_locks.pid                 AS blocking_pid,
+
+    blocking_activity.query            AS blocking_statement
+
+FROM pg_catalog.pg_locks               blocked_locks
+
+JOIN pg_catalog.pg_stat_activity       blocked_activity
+    ON blocked_activity.pid            = blocked_locks.pid
+
+JOIN pg_catalog.pg_locks               blocking_locks
+    ON  blocking_locks.locktype        = blocked_locks.locktype
+    AND blocking_locks.DATABASE        IS NOT DISTINCT FROM blocked_locks.DATABASE
+    AND blocking_locks.relation        IS NOT DISTINCT FROM blocked_locks.relation
+    AND blocking_locks.page            IS NOT DISTINCT FROM blocked_locks.page
+    AND blocking_locks.tuple           IS NOT DISTINCT FROM blocked_locks.tuple
+    AND blocking_locks.virtualxid      IS NOT DISTINCT FROM blocked_locks.virtualxid
+    AND blocking_locks.transactionid   IS NOT DISTINCT FROM blocked_locks.transactionid
+    AND blocking_locks.classid         IS NOT DISTINCT FROM blocked_locks.classid
+    AND blocking_locks.objid           IS NOT DISTINCT FROM blocked_locks.objid
+    AND blocking_locks.objsubid        IS NOT DISTINCT FROM blocked_locks.objsubid
+    AND blocking_locks.pid             != blocked_locks.pid
+
+JOIN pg_catalog.pg_stat_activity blocking_activity
+     ON blocking_activity.pid          = blocking_locks.pid
+
+WHERE NOT blocked_locks.GRANTED
+      AND blocked_activity.application_name = :app_name;
+
+"""
+
+
+GRANT_READ_PRIVS_SQL = """
+BEGIN;
+GRANT SELECT ON TABLE {table} TO {user};
+COMMIT;
+"""
+
+GRANT_WRITE_PRIVS_SQL = """
+BEGIN;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE {table} TO {user};
+COMMIT;
+"""
+
+REVOKE_READ_PRIVS_SQL = """
+BEGIN;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLE {table} FROM {user};
+COMMIT;
+"""
+
+REVOKE_WRITE_PRIVS_SQL = """
+BEGIN;
+REVOKE INSERT, UPDATE, DELETE ON TABLE {table} FROM {user};
+COMMIT;
+"""
+
+
+def execute(engine, sql, *args, **kwargs):
+    statement = sa.sql.text(sql)
+    logger.debug(statement)
+    return engine.execute(statement, *args, **kwargs)
+
+
+def get_engine(host, user, password, database):
+    connect_args = {"application_name": app_name}
+    con_str = "postgres://{user}:{pwd}@{host}/{db}".format(
+        user=user, host=host, pwd=password, db=database
+    )
+    return create_engine(con_str, connect_args=connect_args)
+
+
+def execute_for_all_graph_tables(engine, sql, *args, **kwargs):
+    """Execute a SQL statment that has a python format variable {table}
+    to be replaced with the tablename for all Node and Edge tables
+
+    """
+    for cls in Node.__subclasses__() + Edge.__subclasses__():
+        _kwargs = dict(kwargs, **{'table': cls.__tablename__})
+        statement = sql.format(**_kwargs)
+        execute(engine, statement)
+
+
+def grant_read_permissions_to_graph(engine, user):
+    execute_for_all_graph_tables(engine, GRANT_READ_PRIVS_SQL, user=user)
+
+
+def grant_write_permissions_to_graph(engine, user):
+    execute_for_all_graph_tables(engine, GRANT_WRITE_PRIVS_SQL, user=user)
+
+
+def revoke_read_permissions_to_graph(engine, user):
+    execute_for_all_graph_tables(engine, REVOKE_READ_PRIVS_SQL, user=user)
+
+
+def revoke_write_permissions_to_graph(engine, user):
+    execute_for_all_graph_tables(engine, REVOKE_WRITE_PRIVS_SQL, user=user)
+
+
+def create_graph_tables(engine, timeout):
+    """
+    create a table
+    """
+    logger.info('Creating tables (timeout: %d)', timeout)
+
+    connection = engine.connect()
+    trans = connection.begin()
+    logger.info("Setting lock_timeout to %d", timeout)
+
+    timeout_str = '{}s'.format(int(timeout+1))
+    connection.execute("SET LOCAL lock_timeout = %s;", timeout_str)
+
+    create_all(connection)
+    trans.commit()
+
+
+def is_blocked_by_no_kill(blocking):
+    for proc in blocking:
+        if proc.blocking_appname in no_kill_list:
+            print 'Blocked by no-kill process {}, {}: {}'.format(
+                proc.blocking_appname, proc.blocking_pid,
+                proc.blocking_statement)
+            return True
+    return False
+
+
+def lookup_blocking_psql_backend_processes(engine):
+    """
+    """
+
+    sql_cmd = sa.sql.text(BLOCKING_SQL)
+    conn = engine.connect()
+    blocking = conn.execute(sql_cmd, app_name=app_name)
+    return [BlockingQueryResult(*b) for b in blocking]
+
+
+def kill_blocking_psql_backend_processes(engine):
+    """Query the postgres backend tables for the process that is blocking
+    this app, as identified by the `app_name`.
+
+    .. warning:: **THIS COMMAND KILLS OTHER PEOPLES POSTGRES QUERIES.**
+
+    It is sometimes necessary to kill other peoples queries in order
+    to gain a write lock on a table to ALTER it for a foreign-key from
+    a new table.
+
+    There is a list at the top of this module that specifies which
+    processes are 'no-kill'.  There currently are none, but a good
+    exmaple of one that you might want to put in there is the
+    Elasticsearch build process, since you might not want to kill a 5h
+    long process 4h in.
+
+    """
+
+    blockers = lookup_blocking_psql_backend_processes(engine)
+
+    if is_blocked_by_no_kill(blockers):
+        logger.warn("Process blocked by a 'no-kill' process. "
+                    "Refusing to kill it")
+        return
+
+    if not blockers:
+        logger.warning("Found %d blocking processes!", len(blockers))
+    else:
+        logger.info("Found %d blocking processes", len(blockers))
+
+    for result in blockers:
+        logger.warning(
+            'Killing blocking backend process: name({})\tpid({}): {}'.format(
+                result.blocking_appname,
+                result.blocking_pid,
+                result.blocking_statement)
+        )
+
+        # Kill anything in the way, it was deemed of low importance
+        sql_cmd = 'SELECT pg_terminate_backend({blocking_pid});'.format(
+            blocking_pid=result.blocking_pid
+        )
+        execute(engine, sql_cmd)
+
+
+def create_tables_force(engine, delay, retries):
+    """Create the tables and **KILL ANY BLOCKING PROCESSES**.
+
+    This command will spawn a process to create the new tables in
+    order to find out which process is blocking us.  If we didn't do
+    this concurrently, then the table creation will have disappeared
+    by the time we tried to find its blocker in the postgres backend
+    tables.
+
+    """
+
+    logger.info('Running table creator named %s', app_name)
+    logger.warning('Running with force=True option %s', app_name)
+
+    from multiprocessing import Process
+    p = Process(target=create_graph_tables, args=(engine, delay))
+    p.start()
+    time.sleep(delay)
+
+    if p.is_alive():
+        logger.warning('Table creation blocked!')
+        kill_blocking_psql_backend_processes(engine)
+
+        #  Wait some time for table creation to proceed
+        time.sleep(4)
+
+    if p.is_alive():
+        if retries <= 0:
+            raise RuntimeError('Max retries exceeded.')
+
+        logger.warning('Table creation failed, retrying.')
+        return create_tables_force(engine, delay, retries-1)
+
+
+def create_tables(engine, delay, retries):
+    """Create the tables but do not kill any blocking processes.
+
+    This command will catch OperationalErrors signalling timeouts from
+    the database when the lock was not obtained successfully within
+    the `delay` period.
+
+    """
+
+    logger.info('Running table creator named %s', app_name)
+    try:
+        return create_graph_tables(engine, delay)
+
+    except OperationalError as e:
+        if 'timeout' in str(e):
+            logger.warning('Attempt timed out')
+        else:
+            raise
+
+        if retries <= 0:
+            raise RuntimeError('Max retries exceeded')
+
+        logger.info(
+            'Trying again in {} seconds ({} retries remaining)'
+            .format(delay, retries))
+        time.sleep(delay)
+
+        create_tables(engine, delay, retries-1)
+
+
+def subcommand_create(args):
+    """Idempotently/safely create ALL tables in database that are required
+    for the GDC.  This command will not delete/drop any data.
+
+    """
+
+    logger.info("Running subcommand 'create'")
+    engine = get_engine(args.host, args.user, args.password, args.database)
+    kwargs = dict(
+        engine=engine,
+        delay=args.delay,
+        retries=args.retries,
+    )
+
+    if args.force:
+        return create_tables_force(**kwargs)
+    else:
+        return create_tables(**kwargs)
+
+
+def subcommand_grant(args):
+    """Grant permissions to a user.
+
+    Argument ``--read`` will grant users read permissions
+    Argument ``--write`` will grant users write and READ permissions
+    """
+
+    logger.info("Running subcommand 'grant'")
+    engine = get_engine(args.host, args.user, args.password, args.database)
+
+    assert args.read or args.write, 'No premission types/users specified.'
+
+    if args.read:
+        users_read = [u for u in args.read.split(',') if u]
+        for user in users_read:
+            grant_read_permissions_to_graph(engine, user)
+
+    if args.write:
+        users_write = [u for u in args.write.split(',') if u]
+        for user in users_write:
+            grant_write_permissions_to_graph(engine, user)
+
+
+def subcommand_revoke(args):
+    """Grant permissions to a user.
+
+    Argument ``--read`` will revoke users' read permissions
+    Argument ``--write`` will revoke users' write AND READ permissions
+    """
+
+    logger.info("Running subcommand 'revoke'")
+    engine = get_engine(args.host, args.user, args.password, args.database)
+
+    if args.read:
+        users_read = [u for u in args.read.split(',') if u]
+        for user in users_read:
+            revoke_read_permissions_to_graph(engine, user)
+
+    if args.write:
+        users_write = [u for u in args.write.split(',') if u]
+        for user in users_write:
+            revoke_write_permissions_to_graph(engine, user)
+
+
+def add_base_args(subparser):
+    subparser.add_argument("-H", "--host", type=str, action="store",
+                           required=True, help="psql-server host")
+    subparser.add_argument("-U", "--user", type=str, action="store",
+                           required=True, help="psql test user")
+    subparser.add_argument("-D", "--database", type=str, action="store",
+                           required=True, help="psql test database")
+    subparser.add_argument("-P", "--password", type=str, action="store",
+                           default='', help="psql test password")
+    return subparser
+
+
+def add_subcommand_create(subparsers):
+    parser = add_base_args(subparsers.add_parser(
+        'create',
+        help=subcommand_create.__doc__
+    ))
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Hard killing blocking processes that are not in the 'no-kill' list."
+    )
+    parser.add_argument(
+        "--delay", type=int, action="store", default=60,
+        help="How many seconds to wait for blocking processes to finish before retrying (and hard killing them if used with --force)."
+    )
+    parser.add_argument(
+        "--retries", type=int, action="store", default=10,
+        help="If blocked by important process, how many times to retry after waiting `delay` seconds."
+    )
+
+
+def add_subcommand_grant(subparsers):
+    parser = add_base_args(subparsers.add_parser(
+        'graph-grant',
+        help=subcommand_grant.__doc__
+    ))
+    parser.add_argument(
+        "--read", type=str, action="store",
+        help="Users to grant read access to (comma separated)."
+    )
+    parser.add_argument(
+        "--write", type=str, action="store",
+        help="Users to grant read/write access to (comma separated)."
+    )
+
+
+def add_subcommand_revoke(subparsers):
+    parser = add_base_args(subparsers.add_parser(
+        'graph-revoke',
+        help=subcommand_revoke.__doc__
+    ))
+    parser.add_argument(
+        "--read", type=str, action="store",
+        help="Users to revoke read access from (comma separated)."
+    )
+    parser.add_argument(
+        "--write", type=str, action="store",
+        help=("Users to revoke write access from (comma separated). "
+              "NOTE: The user will still have read privs!!")
+    )
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand")
+    add_subcommand_create(subparsers)
+    add_subcommand_grant(subparsers)
+    add_subcommand_revoke(subparsers)
+    return parser
+
+
+def main(args=None):
+    args = args or get_parser().parse_args()
+
+    logger.info("[ HOST     : %-10s ]", args.host)
+    logger.info("[ DATABASE : %-10s ]", args.database)
+    logger.info("[ USER     : %-10s ]", args.user)
+
+    return_value = {
+        'create': subcommand_create,
+        'graph-grant': subcommand_grant,
+        'graph-revoke': subcommand_revoke,
+    }[args.subcommand](args)
+
+    logger.info("Done.")
+    return return_value

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ setup(
         'git+ssh://git@github.com/NCI-GDC/psqlgraph.git@f0f198c2d7978fea311b0bc311c6db61732de261#egg=psqlgraph',
         'git+ssh://git@github.com/NCI-GDC/gdcdictionary.git@05a25651affbebd7f0eab9b03758645b4c20047a#egg=gdcdictionary',
     ],
-    scripts=[
-        'bin/setup_psqlgraph.py',
-    ]
+    entry_points={
+        'console_scripts': [
+            'gdc_postgres_admin=gdcdatamodel.gdc_postgres_admin:main'
+        ]
+    },
 )

--- a/test/test_gdc_postgres_admin.py
+++ b/test/test_gdc_postgres_admin.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for gdcdatamodel.gdc_postgres_admin module
+"""
+
+import logging
+import unittest
+
+from gdcdatamodel import gdc_postgres_admin as pgadmin
+from gdcdatamodel import models
+from sqlalchemy.exc import ProgrammingError
+
+from multiprocessing import (
+    Process,
+    Queue,
+)
+
+from psqlgraph import (
+    Edge,
+    Node,
+    PsqlGraphDriver,
+)
+
+logging.basicConfig()
+
+
+class TestGDCPostgresAdmin(unittest.TestCase):
+
+    logger = logging.getLogger('TestGDCPostgresAdmin')
+    logger.setLevel(logging.INFO)
+
+    host = 'localhost'
+    user = 'postgres'
+    database = 'automated_test'
+
+    base_args = [
+        '-H', host,
+        '-U', user,
+        '-D', database,
+    ]
+
+    g = PsqlGraphDriver(host, user, '', database)
+    root_con_str = "postgres://{user}:{pwd}@{host}/{db}".format(
+        user=user, host=host, pwd='', db=database)
+    engine = pgadmin.create_engine(root_con_str)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Recreate the database for tests that follow.
+
+        """
+        cls.create_all_tables()
+
+        # Re-grant permissions to test user
+        for scls in Node.__subclasses__() + Edge.__subclasses__():
+            statment = ("GRANT ALL PRIVILEGES ON TABLE {} TO test"
+                        .format(scls.__tablename__))
+            cls.engine.execute('BEGIN; %s; COMMIT;' % statment)
+
+    @classmethod
+    def drop_all_tables(cls):
+        for scls in Edge.__subclasses__() + Node.__subclasses__():
+            try:
+                cls.engine.execute("DROP TABLE {}".format(scls.__tablename__))
+            except Exception as e:
+                cls.logger.debug(e)
+
+    @classmethod
+    def create_all_tables(cls):
+        parser = pgadmin.get_parser()
+        args = parser.parse_args([
+            'create', '--delay', '1', '--retries', '0', '--force'
+        ] + cls.base_args)
+        pgadmin.main(args)
+
+    @classmethod
+    def drop_a_table(cls):
+        cls.engine.execute('DROP TABLE edge_clinicaldescribescase')
+        cls.engine.execute('DROP TABLE node_clinical')
+
+    def startTestRun(self):
+        self.drop_all_tables()
+
+    def setUp(self):
+        self.drop_all_tables()
+
+    def test_args(self):
+        parser = pgadmin.get_parser()
+        parser.parse_args(['create'] + self.base_args)
+
+    def test_create_single(self):
+        """Test simple table creation"""
+
+        pgadmin.main(pgadmin.get_parser().parse_args([
+            'create', '--delay', '1', '--retries', '0'
+        ] + self.base_args))
+
+        self.engine.execute('SELECT * from node_case')
+
+    def test_create_double(self):
+        """Test idempotency of table creation"""
+
+        pgadmin.main(pgadmin.get_parser().parse_args([
+            'create', '--delay', '1', '--retries', '0'
+        ] + self.base_args))
+
+        self.engine.execute('SELECT * from node_case')
+
+    def test_create_fails_blocked_without_force(self):
+        """Test table creation fails when blocked w/o force"""
+
+        q = Queue()  # to communicate with blocking process
+
+        args = pgadmin.get_parser().parse_args([
+            'create', '--delay', '1', '--retries', '1'
+        ] + self.base_args)
+        pgadmin.main(args)
+
+        self.drop_a_table()
+
+        def blocker():
+            with self.g.session_scope() as s:
+                s.merge(models.Case('1'))
+                q.put(0)  # Tell main thread we're ready
+                q.get()   # Wait for main thread to tell us to exit
+
+        p = Process(target=blocker)
+        p.daemon = True
+        p.start()
+        q.get()
+
+        with self.assertRaises(RuntimeError):
+            pgadmin.main(args)
+
+        q.put(0)
+        p.terminate()
+
+    def test_create_force(self):
+        """Test ability to force table creation"""
+
+        q = Queue()  # to communicate with blocking process
+
+        args = pgadmin.get_parser().parse_args([
+            'create', '--delay', '1', '--retries', '1', '--force'
+        ] + self.base_args)
+        pgadmin.main(args)
+
+        self.drop_a_table()
+
+        def blocker():
+            with self.g.session_scope() as s:
+                s.merge(models.Case('1'))
+                q.put(0)  # Tell main thread we're ready
+                q.get()   # This get should block until this prcoess is killed
+                assert False, 'Should not be reachable!'
+
+        p = Process(target=blocker)
+        p.daemon = True
+        p.start()
+        q.get()
+
+        try:
+            pgadmin.main(args)
+        except:
+            p.terminate()
+            raise
+
+        q.put(0)
+        p.terminate()
+
+    def test_priv_grant_read(self):
+        """Test ability to grant read but not write privs"""
+
+        self.create_all_tables()
+        self.engine.execute("CREATE USER pytest WITH PASSWORD 'pyt3st'")
+
+        try:
+            g = PsqlGraphDriver(self.host, 'pytest', 'pyt3st', self.database)
+
+            #: If this failes, this test (not the code) is wrong!
+            with self.assertRaises(ProgrammingError):
+                with g.session_scope():
+                    g.nodes().count()
+
+            pgadmin.main(pgadmin.get_parser().parse_args([
+                'graph-grant', '--read=pytest',
+            ] + self.base_args))
+
+            with g.session_scope():
+                g.nodes().count()
+
+            with self.assertRaises(ProgrammingError):
+                with g.session_scope() as s:
+                    s.merge(models.Case('1'))
+
+        finally:
+            self.engine.execute("DROP OWNED BY pytest; DROP USER pytest")
+
+    def test_priv_grant_write(self):
+        """Test ability to grant read/write privs"""
+
+        self.create_all_tables()
+        self.engine.execute("CREATE USER pytest WITH PASSWORD 'pyt3st'")
+
+        try:
+            g = PsqlGraphDriver(self.host, 'pytest', 'pyt3st', self.database)
+            pgadmin.main(pgadmin.get_parser().parse_args([
+                'graph-grant', '--write=pytest',
+            ] + self.base_args))
+
+            with g.session_scope() as s:
+                g.nodes().count()
+                s.merge(models.Case('1'))
+
+        finally:
+            self.engine.execute("DROP OWNED BY pytest; DROP USER pytest")
+
+    def test_priv_revoke_read(self):
+        """Test ability to revoke read privs"""
+
+        self.create_all_tables()
+        self.engine.execute("CREATE USER pytest WITH PASSWORD 'pyt3st'")
+
+        try:
+            g = PsqlGraphDriver(self.host, 'pytest', 'pyt3st', self.database)
+
+            pgadmin.main(pgadmin.get_parser().parse_args([
+                'graph-grant', '--read=pytest',
+            ] + self.base_args))
+
+            pgadmin.main(pgadmin.get_parser().parse_args([
+                'graph-revoke', '--read=pytest',
+            ] + self.base_args))
+
+            with self.assertRaises(ProgrammingError):
+                with g.session_scope() as s:
+                    g.nodes().count()
+                    s.merge(models.Case('1'))
+
+        finally:
+            self.engine.execute("DROP OWNED BY pytest; DROP USER pytest")
+
+    def test_priv_revoke_write(self):
+        """Test ability to revoke read/write privs"""
+
+        self.create_all_tables()
+        self.engine.execute("CREATE USER pytest WITH PASSWORD 'pyt3st'")
+
+        try:
+            g = PsqlGraphDriver(self.host, 'pytest', 'pyt3st', self.database)
+
+            pgadmin.main(pgadmin.get_parser().parse_args([
+                'graph-grant', '--write=pytest',
+            ] + self.base_args))
+
+            pgadmin.main(pgadmin.get_parser().parse_args([
+                'graph-revoke', '--write=pytest',
+            ] + self.base_args))
+
+            with g.session_scope() as s:
+                g.nodes().count()
+
+            with self.assertRaises(ProgrammingError):
+                with g.session_scope() as s:
+                    s.merge(models.Case('1'))
+
+        finally:
+            self.engine.execute("DROP OWNED BY pytest; DROP USER pytest")


### PR DESCRIPTION
Adds entrypoint to `gdcdatamodel`:

```
gdc_postgres_admin -h
usage: gdc_postgres_admin [-h] {create,graph-grant,graph-revoke} ...

positional arguments:
  {create,graph-grant,graph-revoke}
    create              Idempotently/safely create ALL tables in database that
                        are required for the GDC. This command will not
                        delete/drop any data.
    graph-grant         Grant permissions to a user. Argument ``--read`` will
                        grant users read permissions Argument ``--write`` will
                        grant users write and READ permissions
    graph-revoke        Grant permissions to a user. Argument ``--read`` will
                        revoke users' read permissions Argument ``--write``
                        will revoke users' write AND READ permissions

optional arguments:
  -h, --help            show this help message and exit
```

r? @NCI-GDC/ucdevs 
