### PR TITLE
feat(datamodel): assert no link/backref collision

### DIFF
--- a/test/test_datamodel.py
+++ b/test/test_datamodel.py
@@ -28,3 +28,25 @@ class TestDataModel(unittest.TestCase):
         with self.assertRaises(ValidationError):
             s.percent_necrosis = '0.0'
         s.percent_necrosis = 0.0
+
+    def test_link_clobber_prevention(self):
+        with self.assertRaises(AssertionError):
+            md.EdgeFactory(
+                'Testedge',
+                'test',
+                'sample',
+                'aliquot',
+                'aliquots',
+                '_uncontended_backref',
+            )
+
+    def test_backref_clobber_prevention(self):
+        with self.assertRaises(AssertionError):
+            md.EdgeFactory(
+                'Testedge',
+                'test',
+                'sample',
+                'aliquot',
+                '_uncontended_link',
+                'samples',
+            )


### PR DESCRIPTION
This prevents clobbering a backref with a link or a link with a backref, as they would be from different nodes, should be different relationships, and would have different semantic meanings.

r? @philloooo 
