### PR TITLE
feat(cache): caches related cases

### DIFF
--- a/bin/update_related_case_caches.py
+++ b/bin/update_related_case_caches.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""update_related_case_caches
+--------------------------
+
+Will update the case tree for all non-legacy projects by caching the
+related cases on all nodes.
+
+"""
+
+import argparse
+import getpass
+import logging
+
+from gdcdatamodel import models as md
+from gdcdatamodel.models.caching import CASE_CACHE_KEY
+from psqlgraph import PsqlGraphDriver
+
+
+logging.basicConfig()
+logger = logging.getLogger("update_related_cases_caches")
+logger.setLevel(logging.INFO)
+
+
+def recursive_update_related_case_caches(node, case_id, visited_ids):
+    """Sets the case_id in the cache on the source of all incoming edges
+    and recurses.
+
+    """
+
+    logger.info("{}: | case: {} | project: {}".format(
+        node, case_id, node._props.get('project_id', '?')))
+
+    for edge in node.edges_in:
+        original = set(edge.src.sysan.get(CASE_CACHE_KEY, []))
+        updated = original.union({case_id})
+        edge.src.sysan[CASE_CACHE_KEY] = list(updated)
+        if edge.src_id not in visited_ids:
+            recursive_update_related_case_caches(
+                edge.src, case_id, visited_ids.union({edge.src_id}))
+
+
+def update_project_related_case_cache(project):
+    """Updates the case cache on the full tree under each case in the
+    project
+
+    """
+
+    logger.info("Project: {}".format(project.code))
+    for case in project.cases:
+        recursive_update_related_case_caches(case, case.node_id, set())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-H", "--host", type=str, action="store",
+                        required=True, help="psql-server host")
+    parser.add_argument("-U", "--user", type=str, action="store",
+                        required=True, help="psql test user")
+    parser.add_argument("-D", "--database", type=str, action="store",
+                        required=True, help="psql test database")
+    parser.add_argument("-P", "--password", type=str, action="store",
+                        help="psql test password")
+
+    args = parser.parse_args()
+    prompt = "Password for {}:".format(args.user)
+    password = args.password or getpass.getpass(prompt)
+    g = PsqlGraphDriver(args.host, args.user, password, args.database)
+
+    with g.session_scope():
+        projects = g.nodes(md.Project).not_props(state='legacy').all()
+        map(update_project_related_case_cache, projects)
+
+    print("Done.")
+
+if __name__ == '__main__':
+    main()

--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -15,7 +15,7 @@ propogate to all code that imports this package and MAY BREAK THINGS.
 
 """
 
-from cdisutils import log
+from cdisutils.log import get_logger
 from collections import defaultdict
 from gdcdictionary import gdcdictionary as dictionary
 from misc import FileReport                      # noqa
@@ -41,7 +41,16 @@ from sqlalchemy.ext.hybrid import (
     hybrid_property,
 )
 
-logger = log.get_logger('gdcdatamodel')
+from caching import (                            # noqa
+    CASE_CACHE_KEY,
+    cache_related_cases_on_update,
+    cache_related_cases_on_insert,
+    cache_related_cases_on_delete,
+    related_cases_from_cache,
+    related_cases_from_parents,
+)
+
+logger = get_logger('gdcdatamodel')
 
 # These are properties that are defined outside of the JSONB column in
 # the database, inform later code to skip these
@@ -318,6 +327,18 @@ def NodeFactory(_id, schema):
     # _pg_edges are all edges, links to AND from other types
     attributes['_pg_edges'] = {}
 
+    # _related_cases_from_parents: get ids of related cases from this
+    # nodes's sysan
+    attributes['_related_cases_from_cache'] = property(
+        related_cases_from_cache
+    )
+
+    # _related_cases_from_parents: get ids of related cases from this
+    # nodes parents
+    attributes['_related_cases_from_parents'] = property(
+        related_cases_from_parents
+    )
+
     # Create the Node subclass!
     cls = type(name, (Node,), dict(
         __tablename__=get_class_tablename_from_id(_id),
@@ -428,6 +449,18 @@ def EdgeFactory(name, label, src_label, dst_label, src_dst_assoc,
     _assigned_association_proxies[dst_label].add(dst_src_assoc)
     _assigned_association_proxies[src_label].add(src_dst_assoc)
 
+    hooks_before_insert = Edge._session_hooks_before_insert + [
+        cache_related_cases_on_insert,
+    ]
+
+    hooks_before_update = Edge._session_hooks_before_update + [
+        cache_related_cases_on_update,
+    ]
+
+    hooks_before_delete = Edge._session_hooks_before_delete + [
+        cache_related_cases_on_delete,
+    ]
+
     cls = type(name, (Edge,), {
         '__label__': label,
         '__tablename__': tablename,
@@ -437,6 +470,9 @@ def EdgeFactory(name, label, src_label, dst_label, src_dst_assoc,
         '__dst_src_assoc__': dst_src_assoc,
         '__src_table__': src_cls.__tablename__,
         '__dst_table__': dst_cls.__tablename__,
+        '_session_hooks_before_insert': hooks_before_insert,
+        '_session_hooks_before_update': hooks_before_update,
+        '_session_hooks_before_delete': hooks_before_delete,
     })
 
     return cls

--- a/gdcdatamodel/models/caching.py
+++ b/gdcdatamodel/models/caching.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+"""gdcdatamodel.models.caching
+----------------------------------
+
+Handle information cached on nodes about releationships and other
+graph properties.  This cached information is specific to the current
+GDC datamodel.
+
+
+**cache.related_cases**:
+    It is important for many transactions to know the ancestor cases
+    of a node, so cache a list of related case ids and update the
+    cache when the set of graph edges is modified.  The value of this
+    key in sysan should be a list of case ids
+
+"""
+
+from cdisutils.log import get_logger
+from psqlgraph import Node, Edge
+from sqlalchemy.orm.session import make_transient
+
+logger = get_logger('gdcdatamodel')
+
+
+# This variable specifies the key under which the node_id of related
+# cases is cached.
+CASE_CACHE_KEY = 'cache.related.case.id'
+
+
+def get_edge_src(edge):
+    """Return the edge's source or None.
+
+    Attempts to lookup the node by id if the association proxy is not
+    set.
+
+    """
+
+    if edge.src:
+        src = edge.src
+    elif edge.src_id is not None:
+        src_class = Node.get_subclass_named(edge.__src_class__)
+        src = (edge.get_session().query(src_class)
+               .filter(src_class.node_id == edge.src_id)
+               .first())
+    else:
+        src = None
+    return src
+
+
+def get_edge_dst(edge, allow_query=False):
+    """Return the edge's destination or None.
+
+    """
+
+    if edge.dst:
+        dst = edge.dst
+    elif edge.dst_id is not None and allow_query:
+        dst_class = Node.get_subclass_named(edge.__dst_class__)
+        dst = (edge.get_session().query(dst_class)
+               .filter(dst_class.node_id == edge.dst_id)
+               .first())
+    else:
+        dst = None
+
+    return dst
+
+
+def related_cases_from_cache(node):
+    """Get the cached related case ids from this node's sysan
+
+    :param node: The Node instance
+    :returns: List of str ids
+
+    """
+
+    return node.sysan.get(CASE_CACHE_KEY, [])
+
+
+def related_cases_from_parents(node):
+    """Get the cached related case ids from the parents of this node from
+
+    1. The sysan of any parent nodes
+    2. If any parents are cases, include those ids
+
+    :param node: The Node instance
+    :returns: List of str ids
+
+    """
+
+    # Get the cached ids from parents
+    cases = {
+        case_id
+        for edge in node.edges_out
+        if edge.dst
+        for case_id in edge.dst._related_cases_from_cache
+    }
+
+    # Are any parents cases?
+    for edge in node.edges_out:
+        dst_class = Node.get_subclass_named(edge.__dst_class__)
+        if dst_class.label == 'case' and edge.dst:
+            cases.add(edge.dst.node_id)
+
+    return list(cases)
+
+
+def cache_related_cases_recursive(node,
+                                  session,
+                                  flush_context,
+                                  instances,
+                                  visited_nodes=None):
+    """Update the related case cache on source node and its children
+    recursively iff the this update changes the related case source
+    node's cache.
+
+    :param session: The target Session.
+    :param flush_context:
+        Internal UOWTransaction object which handles the details of
+        the flush.
+    :param instances:
+        Usually None, this is the collection of objects which can be
+        passed to the Session.flush() method (note this usage is
+        deprecated).
+
+    """
+
+    if not node:
+        return
+
+    if visited_nodes and node.node_id in visited_nodes:
+        return
+
+    visited_nodes = (visited_nodes or set()).union({node.node_id})
+
+    current_cases = related_cases_from_cache(node)
+    updated_cases = related_cases_from_parents(node)
+    diff = set(current_cases).symmetric_difference(updated_cases)
+
+    if not diff:
+        return
+
+    node.sysan[CASE_CACHE_KEY] = updated_cases
+    to_recurse = [e for e in node.edges_in if e.src]
+    for edge in to_recurse:
+        cache_related_cases_recursive(
+            get_edge_src(edge),
+            session,
+            flush_context,
+            instances,
+            visited_nodes,
+        )
+
+
+def cache_related_cases_on_insert(target,
+                                  session,
+                                  flush_context,
+                                  instances,
+                                  visited_nodes=None):
+    """Hook on updated edges.  Update the related case cache on source
+    node and its children iff the this update changes the related case
+    source node's cache.
+
+    This will be called when a node association proxy instance is
+    removed.
+
+    :param session: The target Session.
+    :param flush_context:
+        Internal UOWTransaction object which handles the details of
+        the flush.
+    :param instances:
+        Usually None, this is the collection of objects which can be
+        passed to the Session.flush() method (note this usage is
+        deprecated).
+
+    """
+
+    if not target.src:
+        target.src = get_edge_src(target)
+
+    if not target.dst:
+        target.dst = get_edge_dst(target, allow_query=True)
+
+    cache_related_cases_recursive(
+        get_edge_src(target),
+        session,
+        flush_context,
+        instances,
+        visited_nodes,
+    )
+
+
+def cache_related_cases_on_update(target,
+                                  session,
+                                  flush_context,
+                                  instances,
+                                  visited_nodes=None):
+    """Hook on deleted edges.  Update the related case cache on source
+    node and its children.
+
+    This will be called when an edge instance is updated
+    (i.e. association proxy is deleted).
+
+    :param session: The target Session.
+    :param flush_context:
+        Internal UOWTransaction object which handles the details of
+        the flush.
+    :param instances:
+        Usually None, this is the collection of objects which can be
+        passed to the Session.flush() method (note this usage is
+        deprecated).
+
+    """
+
+    cache_related_cases_recursive(
+        get_edge_src(target),
+        session,
+        flush_context,
+        instances,
+        visited_nodes,
+    )
+
+
+def cache_related_cases_on_delete(target,
+                                  session,
+                                  flush_context,
+                                  instances,
+                                  visited_nodes=None):
+    """Hook on deleted edges.  Update the related case cache on source
+    node and its children.
+
+    This will be called when an edge instance is explicitly deleted in
+    the session.
+
+    :param session: The target Session.
+    :param flush_context:
+        Internal UOWTransaction object which handles the details of
+        the flush.
+    :param instances:
+        Usually None, this is the collection of objects which can be
+        passed to the Session.flush() method (note this usage is
+        deprecated).
+
+    """
+
+    # Remove the source and destination of application local
+    # association_proxy so cache_related_cases_update_children doesn't
+    # traverse the edge
+    target.dst, target.src = None, None
+    cache_related_cases_recursive(
+        get_edge_src(target),
+        session,
+        flush_context,
+        instances,
+        visited_nodes,
+    )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     },
     dependency_links=[
         'git+ssh://git@github.com/NCI-GDC/cdisutils.git@4a75cc05c7ba2174e70cca9c9ea7e93947f7a868#egg=cdisutils',
-        'git+ssh://git@github.com/NCI-GDC/psqlgraph.git@c71ff0b804b81dde01d4a8eb743ada45540650c5#egg=psqlgraph',
+        'git+ssh://git@github.com/NCI-GDC/psqlgraph.git@4fbeddeb058ad09741c5d2b9aacbd1c63cfc3dd1#egg=psqlgraph',
         'git+ssh://git@github.com/NCI-GDC/gdcdictionary.git@e3bd0932da1722b926c75db57a1df4527cdc27fa#egg=gdcdictionary',
     ],
     entry_points={

--- a/test/test_cache_related_cases.py
+++ b/test/test_cache_related_cases.py
@@ -1,0 +1,212 @@
+from gdcdatamodel import models as md
+from psqlgraph import Node, Edge, PsqlGraphDriver
+
+import unittest
+
+host = 'localhost'
+user = 'test'
+password = 'test'
+database = 'automated_test'
+g = PsqlGraphDriver(host, user, password, database)
+
+
+class TestCacheRelatedCases(unittest.TestCase):
+
+    def setUp(self):
+        self._clear_tables()
+
+    def tearDown(self):
+        self._clear_tables()
+
+    def _clear_tables(self):
+        conn = g.engine.connect()
+        conn.execute('commit')
+        for table in Node().get_subclass_table_names():
+            if table != Node.__tablename__:
+                conn.execute('delete from {}'.format(table))
+        for table in Edge.get_subclass_table_names():
+            if table != Edge.__tablename__:
+                conn.execute('delete from {}'.format(table))
+        conn.execute('delete from versioned_nodes')
+        conn.execute('delete from _voided_nodes')
+        conn.execute('delete from _voided_edges')
+        conn.close()
+
+    def test_insert_single_association_proxy(self):
+        with g.session_scope() as s:
+            case = md.Case('case_id_1')
+            sample = md.Sample('sample_id_1')
+            sample.cases = [case]
+            s.merge(sample)
+
+        with g.session_scope() as s:
+            sample = g.nodes(md.Sample).subq_path('cases').one()
+            assert sample.sysan[md.CASE_CACHE_KEY] == ['case_id_1']
+
+    def test_insert_single_edge(self):
+        with g.session_scope() as s:
+            case = s.merge(md.Case('case_id_1'))
+            sample = s.merge(md.Sample('sample_id_1'))
+            edge = md.SampleDerivedFromCase(sample.node_id, case.node_id)
+            s.merge(edge)
+
+        with g.session_scope() as s:
+            sample = g.nodes(md.Sample).subq_path('cases').one()
+            assert sample.sysan[md.CASE_CACHE_KEY] == ['case_id_1']
+
+    def test_insert_double_edge_in(self):
+        with g.session_scope() as s:
+            case = md.Case('case_id_1')
+            sample1 = md.Sample('sample_id_1')
+            sample2 = md.Sample('sample_id_2')
+            case.samples = [sample1, sample2]
+            s.merge(case)
+
+        with g.session_scope() as s:
+            samples = g.nodes(md.Sample).subq_path('cases').all()
+            self.assertEqual(len(samples), 2)
+            for sample in samples:
+                assert sample.sysan[md.CASE_CACHE_KEY] == ['case_id_1']
+
+    def test_insert_double_edge_out(self):
+        with g.session_scope() as s:
+            case1 = md.Case('case_id_1')
+            case2 = md.Case('case_id_2')
+            sample = md.Sample('sample_id_1')
+            sample.cases = [case1, case2]
+            s.merge(sample)
+
+        with g.session_scope() as s:
+            sample = g.nodes(md.Sample).subq_path('cases').one()
+            assert sample.sysan[md.CASE_CACHE_KEY] == [
+                'case_id_1',
+                'case_id_2',
+            ]
+
+    def test_insert_multiple_edges(self):
+        with g.session_scope() as s:
+            case = md.Case('case_id_1')
+            sample = md.Sample('sample_id_1')
+            portion = md.Portion('portion_id_1')
+            analyte = md.Analyte('analyte_id_1')
+            aliquot = md.Aliquot('aliquot_id_1')
+            submitted_file = md.SubmittedFile('file_id_1')
+
+            sample.cases = [case]
+            portion.samples = [sample]
+            analyte.portions = [portion]
+            aliquot.analytes = [analyte]
+            submitted_file.aliquots = [aliquot]
+            s.merge(case)
+
+        with g.session_scope() as s:
+            nodes = g.nodes(Node).all()
+            nodes = [n for n in nodes if n.label not in ['case']]
+
+        for node in nodes:
+            assert node.sysan == {md.CASE_CACHE_KEY: ['case_id_1']}, node
+
+    def test_insert_update_children(self):
+        with g.session_scope() as s:
+            aliquot = s.merge(md.Aliquot('aliquot_id_1'))
+            sample = s.merge(md.Sample('sample_id_1'))
+            aliquot.samples = [sample]
+            s.merge(md.Case('case_id_1'))
+
+        with g.session_scope() as s:
+            case = g.nodes(md.Case).one()
+            sample = g.nodes(md.Sample).one()
+            sample.cases = [case]
+
+        with g.session_scope() as s:
+            aliquot = g.nodes(md.Aliquot).one()
+            sample = g.nodes(md.Sample).one()
+
+        assert sample.sysan == {md.CASE_CACHE_KEY: ['case_id_1']}
+        assert aliquot.sysan == {md.CASE_CACHE_KEY: ['case_id_1']}
+
+    def test_delete_dst_association_proxy(self):
+        with g.session_scope() as s:
+            case = md.Case('case_id_1')
+            aliquot = md.Aliquot('aliquot_id_1')
+            sample = md.Sample('sample_id_1')
+            aliquot.samples = [sample]
+            sample.cases = [case]
+            s.merge(case)
+
+        with g.session_scope() as s:
+            case = g.nodes(md.Case).one()
+            case.samples = []
+
+        with g.session_scope() as s:
+            assert not g.nodes(md.Sample).subq_path('cases').count()
+
+        with g.session_scope() as s:
+            sample = g.nodes(md.Sample).one()
+            aliquot = g.nodes(md.Aliquot).one()
+
+            assert sample.sysan == {md.CASE_CACHE_KEY: []}
+            assert aliquot.sysan == {md.CASE_CACHE_KEY: []}
+
+    def test_delete_src_association_proxy(self):
+        with g.session_scope() as s:
+            case = md.Case('case_id_1')
+            aliquot = md.Aliquot('aliquot_id_1')
+            sample = md.Sample('sample_id_1')
+            aliquot.samples = [sample]
+            sample.cases = [case]
+            s.merge(case)
+
+        with g.session_scope() as s:
+            sample = g.nodes(md.Sample).one()
+            sample.cases = []
+
+        with g.session_scope() as s:
+            assert not g.nodes(md.Sample).subq_path('cases').count()
+
+        with g.session_scope() as s:
+            sample = g.nodes(md.Sample).one()
+            aliquot = g.nodes(md.Aliquot).one()
+
+            assert sample.sysan == {md.CASE_CACHE_KEY: []}
+            assert aliquot.sysan == {md.CASE_CACHE_KEY: []}
+
+    def test_delete_edge(self):
+        with g.session_scope() as s:
+            case = md.Case('case_id_1')
+            aliquot = md.Aliquot('aliquot_id_1')
+            sample = md.Sample('sample_id_1')
+            aliquot.samples = [sample]
+            sample.cases = [case]
+            s.merge(case)
+
+        with g.session_scope() as s:
+            case = g.nodes(md.Case).one()
+            edge = case.edges_in[0]
+            s.delete(edge)
+
+        with g.session_scope() as s:
+            assert not g.nodes(md.Sample).subq_path('cases').count()
+
+        with g.session_scope() as s:
+            sample = g.nodes(md.Sample).one()
+            aliquot = g.nodes(md.Aliquot).one()
+
+            assert sample.sysan == {md.CASE_CACHE_KEY: []}
+            assert aliquot.sysan == {md.CASE_CACHE_KEY: []}
+
+    def test_delete_parent(self):
+        with g.session_scope() as s:
+            case = md.Case('case_id_1')
+            sample = md.Sample('sample_id_1')
+            sample.cases = [case]
+            s.merge(case)
+
+        with g.session_scope() as s:
+            case = g.nodes(md.Case).one()
+            s.delete(case)
+
+        with g.session_scope() as s:
+            sample = g.nodes(md.Sample).one()
+
+            assert sample.sysan == {md.CASE_CACHE_KEY: []}


### PR DESCRIPTION
Because the relationship of each node with related cases is so important, this PR proposes caching the relationship in a system annotation.

This works as such:
1. A new edge is inserted or deleted
2. On the source node of the edge, update the related case cache by taking the union of the ids of all the destinations of all edges.
3. If the previous step resulted in a change, apply step 1 to all sources of inbound edges (recurse)

Tested for:
- Simple insertions
- Recursive tree updates
- Multiple insertions at once
- Deletions of association proxies
- Deletions of edges

r? @philloooo 
