### PR TITLE
fix(clinical-xpath): remove path for progression_or_recurrence

### DIFF
--- a/gdcdatamodel/xml_mappings/tcga_clinical.yaml
+++ b/gdcdatamodel/xml_mappings/tcga_clinical.yaml
@@ -121,7 +121,7 @@ diagnosis:
         default: not reported
 
       progression_or_recurrence:
-        path: "//clin_shared:regimen_indication[last()]"
+        path: "unknown"
         type: str.lower
         default: not reported
 


### PR DESCRIPTION
So clinical fils with path `clin_shared:regimen_indication` doesn't have enums that's defined in our schema. I removed it and we can verify with Tara about whether this field should be progression_or_recurrence = [clin_shared:regiment_indication](https://github.com/nchbcr/xsd/blob/master/tcga.nci/bcr/xml/clinical/shared/2.7/TCGA_BCR.Shared_Clinical_Elements.xsd#L296-L303) in ['PROGRESSION', 'RECURRENCE'],
and add the logic if she think it's correct
r? @allisonheath @NCI-GDC/ucdevs @NCI-GDC/qa 
