### PR TITLE
chore(dependency): bump dictionary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     dependency_links=[
         'git+ssh://git@github.com/NCI-GDC/cdisutils.git@4a75cc05c7ba2174e70cca9c9ea7e93947f7a868#egg=cdisutils',
         'git+ssh://git@github.com/NCI-GDC/psqlgraph.git@a00ec5c0d3542e6f959e82fed0e46782479c6885#egg=psqlgraph',
-        'git+ssh://git@github.com/NCI-GDC/gdcdictionary.git@5450491cea2daa1197d63ef816ebc8720eb463ba#egg=gdcdictionary',
+        'git+ssh://git@github.com/NCI-GDC/gdcdictionary.git@304b8c76ded5abdf4a8a0e06ce2bd4cec886f060#egg=gdcdictionary',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
bump [gdcdictionary](https://github.com/NCI-GDC/gdcdictionary/pull/92) to release 0.3.24.2
r? @NCI-GDC/ucdevs @NCI-GDC/qa 
