### PR TITLE
fix(age-at-diagnosis): use positive of days_to_birth

### DIFF
--- a/gdcdatamodel/xml_mappings/tcga_clinical.yaml
+++ b/gdcdatamodel/xml_mappings/tcga_clinical.yaml
@@ -59,8 +59,8 @@ diagnosis:
         type: str
 
       age_at_diagnosis:
-        path: //clin_shared:age_at_initial_pathologic_diagnosis|//shared:age_at_initial_pathologic_diagnosis
-        type: int
+        path: ./shared:days_to_birth|./clin_shared:days_to_birth * -1
+        type: float
         term:
 
       days_to_birth:


### PR DESCRIPTION
fixes [PGDC-2087](https://jira.opensciencedatacloud.org/browse/PGDC-2087)
- Change the xpath of `age_at_diagnosis` to the positive of `days_to_birth`
- Change the type of `age_at_diagnosis` to `float` to keep uniform with other ages fields, also because this field is [number](https://github.com/NCI-GDC/gdcdictionary/blob/develop/gdcdictionary/schemas/diagnosis.yaml#L75) in gdcdictionary.

r? @NCI-GDC/ucdevs @allisonheath 
