### PR TITLE
chore(deps): use https not ssh

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(
         ]
     },
     dependency_links=[
-        'git+ssh://git@github.com/NCI-GDC/cdisutils.git@4a75cc05c7ba2174e70cca9c9ea7e93947f7a868#egg=cdisutils',
-        'git+ssh://git@github.com/NCI-GDC/psqlgraph.git@a00ec5c0d3542e6f959e82fed0e46782479c6885#egg=psqlgraph',
-        'git+ssh://git@github.com/NCI-GDC/gdcdictionary.git@5152302276dead9692240ddd735272949833c2ca#egg=gdcdictionary',
+        'git+https://github.com/NCI-GDC/cdisutils.git@4a75cc05c7ba2174e70cca9c9ea7e93947f7a868#egg=cdisutils',
+        'git+https://github.com/NCI-GDC/psqlgraph.git@a00ec5c0d3542e6f959e82fed0e46782479c6885#egg=psqlgraph',
+        'git+https://github.com/NCI-GDC/gdcdictionary.git@5152302276dead9692240ddd735272949833c2ca#egg=gdcdictionary',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
The required libraries are now open source ,which means they can be clone via https, not ssh.  This should hopefully fix travis setup.

