### PR TITLE
feat(tx_log): tx_log.closed

### DIFF
--- a/gdcdatamodel/models/submission.py
+++ b/gdcdatamodel/models/submission.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from json import loads, dumps
 from sqlalchemy import func
 from sqlalchemy.dialects.postgres import JSONB
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, deferred
 
@@ -22,6 +22,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Integer,
+    Index,
     Text,
     text,
 )
@@ -35,6 +36,19 @@ def datetime_to_unix(dt):
 
 class TransactionLog(Base):
     __tablename__ = 'transaction_logs'
+
+    @declared_attr
+    def __table_args__(cls):
+        tbl = cls.__tablename__
+        return (
+            Index('{}_program_idx'.format(tbl), 'program'),
+            Index('{}_project_idx'.format(tbl), 'project'),
+            Index('{}_is_dry_run_idx'.format(tbl), 'is_dry_run'),
+            Index('{}_committed_by_idx'.format(tbl), 'committed_by'),
+            Index('{}_closed_idx'.format(tbl), 'closed'),
+            Index('{}_state_idx'.format(tbl), 'state'),
+            Index('{}_submitter_idx'.format(tbl), 'submitter'),
+        )
 
     def __repr__(self):
         return "<TransactionLog({}, {})>".format(
@@ -121,6 +135,12 @@ class TransactionLog(Base):
     #: Has this transaction succeeded, errored, failed, etc.
     state = Column(
         Text,
+        nullable=False,
+    )
+
+    closed = Column(
+        Boolean,
+        default=False,
         nullable=False,
     )
 

--- a/migrations/async_transactions.py
+++ b/migrations/async_transactions.py
@@ -26,6 +26,15 @@ def up_transaction(connection):
     ALTER TABLE transaction_logs ADD COLUMN state        TEXT;
     ALTER TABLE transaction_logs ADD COLUMN committed_by INTEGER;
     ALTER TABLE transaction_logs ADD COLUMN is_dry_run   BOOLEAN;
+    ALTER TABLE transaction_logs ADD COLUMN closed       BOOLEAN NOT NULL DEFAULT FALSE;
+
+    CREATE INDEX transaction_logs_program_idx on transaction_logs (program);
+    CREATE INDEX transaction_logs_project_idx on transaction_logs (project);
+    CREATE INDEX transaction_logs_is_dry_run_idx on transaction_logs  (is_dry_run);
+    CREATE INDEX transaction_logs_committed_by_idx on transaction_logs  (committed_by);
+    CREATE INDEX transaction_logs_closed_idx on transaction_logs (closed);
+    CREATE INDEX transaction_logs_state_idx on transaction_logs (state);
+    CREATE INDEX transaction_logs_submitter_idx on transaction_logs (submitter);
 
     UPDATE transaction_logs SET state      = 'SUCCEEDED'  WHERE state       IS NULL;
     UPDATE transaction_logs SET is_dry_run = FALSE        WHERE is_dry_run  IS NULL;
@@ -36,7 +45,16 @@ def down_transaction(connection):
     logger.info('Migrating async-transactions: down')
 
     connection.execute("""
+    DROP INDEX transaction_logs_program_idx;
+    DROP INDEX transaction_logs_project_idx;
+    DROP INDEX transaction_logs_is_dry_run_idx;
+    DROP INDEX transaction_logs_committed_by_idx;
+    DROP INDEX transaction_logs_closed_idx;
+    DROP INDEX transaction_logs_state_idx;
+    DROP INDEX transaction_logs_submitter_idx;
+
     ALTER TABLE transaction_logs DROP COLUMN state;
+    ALTER TABLE transaction_logs DROP COLUMN closed;
     ALTER TABLE transaction_logs DROP COLUMN committed_by;
     ALTER TABLE transaction_logs DROP COLUMN is_dry_run;
     """)


### PR DESCRIPTION
Add `TransactionLog.closed` for  [API-32](https://jira.opensciencedatacloud.org/browse/API-32).

tested in https://github.com/NCI-GDC/gdcapi/pull/592

riders:
- adds indexes for new fields