### PR TITLE
feat(indexes): index (->>) and lower(->>) on secondary keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
     - yes | python setup.py install
     - python bin/destroy_and_setup_psqlgraph.py
     - pip freeze
-script: "nosetests -v"
+script: "py.test -v"

--- a/bin/destroy_and_setup_psqlgraph.py
+++ b/bin/destroy_and_setup_psqlgraph.py
@@ -71,31 +71,7 @@ def create_tables(host, user, password, database):
         user=user, host=host, pwd=password, db=database))
     create_all(engine)
     versioned_nodes.Base.metadata.create_all(engine)
-
-
-def create_indexes(host, user, password, database):
-    print('Creating indexes')
-    engine = create_engine("postgres://{user}:{pwd}@{host}/{db}".format(
-        user=user, host=host, pwd=password, db=database))
-    index = lambda t, c: ["CREATE INDEX ON {} ({})".format(t, x) for x in c]
-    for scls in Node.get_subclasses():
-        tablename = scls.__tablename__
-        map(engine.execute, index(
-            tablename, [
-                'node_id',
-            ]))
-        map(engine.execute, [
-            "CREATE INDEX ON {} USING gin (_sysan)".format(tablename),
-            "CREATE INDEX ON {} USING gin (_props)".format(tablename),
-            "CREATE INDEX ON {} USING gin (_sysan, _props)".format(tablename),
-        ])
-    for scls in Edge.get_subclasses():
-        map(engine.execute, index(
-            scls.__tablename__, [
-                'src_id',
-                'dst_id',
-                'dst_id, src_id',
-            ]))
+    submission.Base.metadata.create_all(engine)
 
 if __name__ == '__main__':
 
@@ -122,4 +98,3 @@ if __name__ == '__main__':
     setup_database(args.user, args.password, args.database,
                    no_drop=args.no_drop, no_user=args.no_user)
     create_tables(args.host, args.user, args.password, args.database)
-    create_indexes(args.host, args.user, args.password, args.database)

--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -43,7 +43,7 @@ from sqlalchemy.ext.hybrid import (
     hybrid_property,
 )
 
-from caching import (
+from .caching import (
     RELATED_CASES_CATEGORIES,
     RELATED_CASES_LINK_NAME,
     cache_related_cases_on_update,
@@ -52,6 +52,12 @@ from caching import (
     related_cases_from_cache,
     related_cases_from_parents,
 )
+
+from .indexes import (
+    cls_add_indexes,
+    get_secondary_key_indexes,
+)
+
 
 logger = get_logger('gdcdatamodel')
 
@@ -289,6 +295,8 @@ def cls_inject_secondary_keys(cls, schema):
     _secondary_keys._is_pg_property = False
     cls._secondary_keys = _secondary_keys
     cls._secondary_keys_dicts = _secondary_keys_dicts
+
+    cls_add_indexes(cls, get_secondary_key_indexes(cls))
 
 
 def NodeFactory(_id, schema):

--- a/gdcdatamodel/models/indexes.py
+++ b/gdcdatamodel/models/indexes.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+"""gdcdatamodel.models.indexes
+----------------------------------
+
+
+Specialization of PsqlGraph Node/Edge indexes specific to the GDC datamodel.
+
+This module can be used to inject indexes into Node classes for common
+query patterns (e.g. secondary_keys).
+
+"""
+
+from cdisutils.log import get_logger
+from sqlalchemy import Index, func, text
+from sqlalchemy.types import DateTime
+import hashlib
+
+logger = get_logger(__name__)
+
+
+def index_name(cls, description):
+    """Standardize index naming.  Because of PostgreSQL's name character
+    limit, this follows a similar scheme to shortening edge names in
+    `gdcdatamodel.generate_edge_tablename()`
+
+    For long names, take the first 8 characters of a hash of the full,
+    un-truncated table name *before* we truncate and prepend this to
+    the truncation.  This gets us a name like
+    ``index_4df72441_famihist_lower_submitte_id``.  This is yet
+    another rather an undesirable workaround. - jsm
+
+    """
+
+    name = 'index_{}_{}'.format(cls.__tablename__, description)
+
+    # If the name is too long, prepend it with the first 8 hex of it's hash
+    # truncate the each part of the name
+    if len(name) > 40:
+        oldname = index_name
+        logger.debug('Edge tablename {} too long, shortening'.format(oldname))
+        name = 'index_{}_{}_{}'.format(
+            str(hashlib.md5(cls.__tablename__).hexdigest())[:8],
+            ''.join([a[:4] for a in cls.label.split('_')])[:20],
+            '_'.join([a[:8] for a in description.split('_')])[:25],
+        )
+
+        logger.debug('Shortening {} -> {}'.format(oldname, index_name))
+
+    return name
+
+
+def get_secondary_key_indexes(cls):
+    """Returns tuple of indexes on the secondary keys on the class
+
+    ..note:: THIS MUST BE CALLED AFTER `cls_inject_secondary_keys()`
+
+    - cls._props[key].astext
+    - lower(cls._props[key].astext)
+
+    """
+
+    #: use text_pattern_ops, allows LIKE statements not starting with %
+    index_op = 'text_pattern_ops'
+    secondary_keys = {key for pair in cls.__pg_secondary_keys for key in pair}
+
+    key_indexes = (
+        Index(
+            index_name(cls, key),
+            cls._props[key].astext.label(key),
+            postgresql_ops={key: index_op},
+        ) for key in secondary_keys
+    )
+
+    lower_key_indexes = (
+        Index(
+            index_name(cls, key+'_lower'),
+            func.lower(cls._props[key].astext).label(key+'_lower'),
+            postgresql_ops={key+'_lower': index_op},
+        ) for key in secondary_keys
+    )
+
+    return tuple(key_indexes) + tuple(lower_key_indexes)
+
+
+def cls_add_indexes(cls, indexes):
+    """Add indexes to given class"""
+
+    map(cls.__table__.append_constraint, indexes)

--- a/gdcdatamodel/models/submission.py
+++ b/gdcdatamodel/models/submission.py
@@ -48,6 +48,7 @@ class TransactionLog(Base):
             Index('{}_closed_idx'.format(tbl), 'closed'),
             Index('{}_state_idx'.format(tbl), 'state'),
             Index('{}_submitter_idx'.format(tbl), 'submitter'),
+            Index('{}_project_id_idx'.format(tbl), cls.program+'_'+cls.project),
         )
 
     def __repr__(self):

--- a/migrations/index_secondary_keys.py
+++ b/migrations/index_secondary_keys.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+migrations.async_transactions
+----------------------------------
+
+Migrates up/down between states A -> B
+A: without
+B: with
+the following indexes per secondary key
+- lower(_props ->> key)
+- _props ->> key
+
+"""
+
+from psqlgraph import Node
+from gdcdatamodel.models import get_secondary_key_indexes
+from gdcdatamodel.models.submission import TransactionLog
+from sqlalchemy import Index
+
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+TX_LOG_PROJECT_ID_IDX = Index(
+    'transaction_logs_project_id_idx',
+    TransactionLog.program+'_'+TransactionLog.project)
+
+
+def up_transaction(connection):
+    logger.info('Migrating async-transactions: up')
+
+    for cls in Node.get_subclasses():
+        for index in get_secondary_key_indexes(cls):
+            logger.info('Creating %s', index.name)
+            index.create(connection)
+    TX_LOG_PROJECT_ID_IDX.create(connection)
+
+
+def down_transaction(connection):
+    logger.info('Migrating async-transactions: down')
+
+    for cls in Node.get_subclasses():
+        for index in get_secondary_key_indexes(cls):
+            logger.info('Dropping %s', index.name)
+            index.drop(connection)
+    TX_LOG_PROJECT_ID_IDX.drop(connection)
+
+
+def up(connection):
+    transaction = connection.begin()
+    try:
+        up_transaction(connection)
+        transaction.commit()
+    except Exception:
+        transaction.rollback()
+        raise
+
+
+def down(connection):
+    transaction = connection.begin()
+    try:
+        down_transaction(connection)
+        transaction.commit()
+    except Exception:
+        transaction.rollback()
+        raise

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""
+gdcdatamodel.test.conftest
+----------------------------------
+
+pytest setup for gdcdatamodel tests
+"""
+
+from psqlgraph import PsqlGraphDriver
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def db_config():
+    return {
+        'host': 'localhost',
+        'user': 'test',
+        'password': 'test',
+        'database': 'automated_test',
+    }
+
+
+@pytest.fixture(scope='session')
+def g(db_config):
+    """Fixture for database driver"""
+
+    return PsqlGraphDriver(**db_config)
+
+
+@pytest.fixture(scope='session')
+def indexes(g):
+    rows = g.engine.execute("""
+        SELECT i.relname as indname,
+               ARRAY(
+               SELECT pg_get_indexdef(idx.indexrelid, k + 1, true)
+               FROM generate_subscripts(idx.indkey, 1) as k
+               ORDER BY k
+               ) as indkey_names
+        FROM   pg_index as idx
+        JOIN   pg_class as i
+        ON     i.oid = idx.indexrelid
+        JOIN   pg_am as am
+        ON     i.relam = am.oid;
+    """).fetchall()
+
+    return { row[0]: row[1] for row in rows }

--- a/test/test_indexes.py
+++ b/test/test_indexes.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""
+gdcdatamodel.test.conftest
+----------------------------------
+
+Test GDC specific index creation.
+
+"""
+
+
+def test_secondary_key_indexes(indexes):
+    assert 'index_node_datasubtype_name_lower' in indexes
+    assert 'index_node_analyte_project_id' in indexes
+    assert 'index_4df72441_famihist_submitte_id_lower' in indexes
+    assert 'transaction_logs_project_id_idx' in indexes


### PR DESCRIPTION
We can get approximately two orders of magnitude speedup on certain frequently used classes of queries by adding indexes on the text representation of the json fields defined as secondary keys in the dictionary.

### Before
```
SELECT count(*) FROM node_case WHERE (lower(node_case._props ->> 'submitter_id') LIKE 'tcga-c9' || '%%');
Time: 12.159 ms

%time g.nodes().filter(Node._props['submitter_id'].astext.startswith('TCGA-C9-A4')).count()
Wall time: 3.94 s
```

### After
```
SELECT count(*) FROM node_case WHERE (lower(node_case._props ->> 'submitter_id') LIKE 'tcga-c9' || '%%');
Time: 0.604 ms

 %time g.nodes().filter(Node._props['submitter_id'].astext.startswith('TCGA-C9-A4')).count()
CPU times: user 17 ms, sys: 3.78 ms, total: 20.8 ms
Wall time: 39.2 ms
```


