### PR TITLE
feat(case-cache): update stale _related_cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
+
 python:
   - "2.7"
+
 addons:
   postgresql: '9.4'
+
 before_script:
     - yes | python setup.py install
     - python bin/destroy_and_setup_psqlgraph.py

--- a/migrations/test_update_case_cache.py
+++ b/migrations/test_update_case_cache.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+gdcdatamodel.test.test_update_case_cache
+----------------------------------
+
+Test functionality to update stale case caches
+
+"""
+
+from gdcdatamodel import models as md
+from psqlgraph import Node, Edge, PsqlGraphDriver
+
+import os
+import pytest
+import sys
+
+import update_case_cache
+
+@pytest.fixture(scope='session')
+def db_config():
+    return {
+        'host': 'localhost',
+        'user': 'test',
+        'password': 'test',
+        'database': 'automated_test',
+    }
+
+
+@pytest.fixture(scope='module')
+def db_driver(db_config):
+    return PsqlGraphDriver(**db_config)
+
+
+@pytest.fixture(scope='module')
+def case_tree(db_driver):
+    """Create tree to test cache cache on"""
+
+    case = md.Case('case')
+    case.samples = [
+        md.Sample('sample1'),
+        md.Sample('sample2'),
+    ]
+    case.samples[0].portions = [
+        md.Portion('portion1'),
+        md.Portion('portion2'),
+    ]
+    case.samples[0].portions[0].analytes = [
+        md.Analyte('analyte1'),
+        md.Analyte('analyte2'),
+    ]
+    case.samples[0].portions[0].analytes[0].aliquots = [
+        md.Aliquot('aliquot1'),
+        md.Aliquot('alituoq2'),
+    ]
+    with db_driver.session_scope() as session:
+        session.merge(case)
+
+
+@pytest.fixture(scope='module')
+def case_tree_no_cache(db_driver, case_tree):
+    """Remove case cache from above tree"""
+
+    with db_driver.session_scope():
+        kwargs = dict(synchronize_session=False)
+        db_driver.nodes(md.SampleRelatesToCase).delete(**kwargs)
+        db_driver.nodes(md.PortionRelatesToCase).delete(**kwargs)
+        db_driver.nodes(md.AnalyteRelatesToCase).delete(**kwargs)
+        db_driver.nodes(md.AliquotRelatesToCase).delete(**kwargs)
+
+
+def test_update_case_cache(db_driver, case_tree_no_cache):
+    """Verify update_cache_cache_tree fixes stale case cache"""
+
+    with db_driver.session_scope():
+        case = db_driver.nodes(md.Case).one()
+        update_case_cache.update_cache_cache_tree(db_driver, case)
+
+    with db_driver.session_scope():
+        nodes = db_driver.nodes().all()
+        nodes = (node for node in nodes if hasattr(node, '_related_cases'))
+
+        for node in nodes:
+            assert node._related_cases

--- a/migrations/update_case_cache.py
+++ b/migrations/update_case_cache.py
@@ -1,0 +1,66 @@
+"""
+gdcdatamodel.migrations.update_case_cache
+--------------------
+
+Functionality to fix stale case caches in _related_cases edge tables.
+
+"""
+
+from gdcdatamodel.models import Case
+
+
+CASE_NEIGHBORS = {link['src_type'] for link in Case._pg_backrefs.values()}
+
+
+def update_related_cases(driver, node_id):
+    """Removes and re-adds the edge between the given node and it's parent
+    to cascade the new relationship to _related_cases through the
+    graph
+
+    """
+
+    with driver.session_scope() as session:
+
+        node = driver.nodes().ids(node_id).one()
+        edges_out = node.edges_out
+
+        for edge in edges_out:
+            edge_cls = edge.__class__
+            copied_edge = edge_cls(
+                src_id=edge.src_id,
+                dst_id=edge.dst_id,
+                properties=dict(edge.props),
+                system_annotations=dict(edge.sysan),
+            )
+
+            # Delete the edge
+            (driver.edges(edge_cls)
+             .filter(edge_cls.src_id == copied_edge.src_id)
+             .filter(edge_cls.dst_id == copied_edge.dst_id)
+             .delete())
+
+            session.expunge(edge)
+
+            # Re-add the edge to force a refresh of the stale cache
+            session.add(copied_edge)
+
+            # Assert the edge was re-added or abort the session
+            (driver.edges(edge_cls)
+             .filter(edge_cls.src_id == copied_edge.src_id)
+             .filter(edge_cls.dst_id == copied_edge.dst_id)
+             .one())
+
+
+def update_cache_cache_tree(driver, case):
+    """Updates the _related_cases case cache for all children in the
+    :param:`case` tree
+
+    """
+
+    visited = set()
+    with driver.session_scope() as session:
+        for neighbor in case.edges_in:
+            if neighbor.src_id in visited:
+                continue
+            update_related_cases(driver, neighbor.src_id)
+            visited.add(neighbor.src_id)

--- a/migrations/update_case_cache.py
+++ b/migrations/update_case_cache.py
@@ -9,8 +9,6 @@ Functionality to fix stale case caches in _related_cases edge tables.
 from gdcdatamodel.models import Case
 
 
-CASE_NEIGHBORS = {link['src_type'] for link in Case._pg_backrefs.values()}
-
 
 def update_related_cases(driver, node_id):
     """Removes and re-adds the edge between the given node and it's parent
@@ -58,7 +56,7 @@ def update_cache_cache_tree(driver, case):
     """
 
     visited = set()
-    with driver.session_scope() as session:
+    with driver.session_scope():
         for neighbor in case.edges_in:
             if neighbor.src_id in visited:
                 continue


### PR DESCRIPTION
Some entities were created with a bug in the case cache cascading logic.  Add a migration to refresh the relationships to cases.

Addresses [DAT-200](https://jira.opensciencedatacloud.org/browse/DAT-200).
