### PR TITLE
fix(migrations): fix update_case_cache_append_only

### DIFF
--- a/migrations/set_null_edge_columns.py
+++ b/migrations/set_null_edge_columns.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+from psqlgraph import Node, Edge
+from gdcdatamodel import models as md
+
+
+CACHE_EDGES = {
+    Node.get_subclass_named(edge.__src_class__): edge
+    for edge in Edge.get_subclasses()
+    if 'RelatesToCase' in edge.__name__
+}
+
+
+def set_null_edge_columns(graph):
+    """Sets null acl, _props, _sysan to empty values for cache edges
+    :param graph: PsqlGraphDriver
+    """
+
+    session = graph.current_session()
+
+    for edge in CACHE_EDGES.values():
+        table = edge.__tablename__
+        print(edge)
+
+        acl = "UPDATE {table} SET acl = '{{}}'::text[] where acl is null"
+        props = "UPDATE {table} SET _props = '{{}}'::jsonb where _props is null"
+        sysan = "UPDATE {table} SET _sysan = '{{}}'::jsonb where _sysan is null"
+
+        session.execute(acl.format(table=table))
+        session.execute(props.format(table=table))
+        session.execute(sysan.format(table=table))
+
+
+def main():
+    print("No main() action defined, please manually call "
+          "set_null_edge_columns(graph)")
+
+
+if __name__ == '__main__':
+    main()

--- a/migrations/update_case_cache_append_only.py
+++ b/migrations/update_case_cache_append_only.py
@@ -13,8 +13,9 @@ CACHE_EDGES = {
 
 LEVEL_1_SQL = """
 
-INSERT INTO {cache_edge_table} (src_id, dst_id)
-SELECT {cls_table}.node_id, node_case.node_id
+INSERT INTO {cache_edge_table} (src_id, dst_id, _props, _sysan, acl)
+SELECT {cls_table}.node_id, node_case.node_id,
+       '{{}}'::jsonb, '{{}}'::jsonb, '{{}}'::text[]
     FROM {cls_table}
 
     -- Step directly to case
@@ -32,8 +33,9 @@ SELECT {cls_table}.node_id, node_case.node_id
 
 APPEND_CACHE_FROM_PARENT_SQL = """
 
-INSERT INTO {cache_edge_table} (src_id, dst_id)
-SELECT DISTINCT {cls_table}.node_id, node_case.node_id
+INSERT INTO {cache_edge_table} (src_id, dst_id, _props, _sysan, acl)
+SELECT DISTINCT {cls_table}.node_id, node_case.node_id,
+                '{{}}'::jsonb, '{{}}'::jsonb, '{{}}'::text[]
     FROM {cls_table}
 
     -- Step to parent


### PR DESCRIPTION
This migration updates all case cache relationships, however it inserted
null values for acl, props, and sysan. This does not violate a null
constraint but did break a downstream assumption about edges.

- fix: set columns to empty, rather than null

```python
from set_null_edge_columns import set_null_edge_columns
set_null_edge_columns(g)
```
