### PR TITLE
chore(validator): improve error message

### DIFF
--- a/gdcdatamodel/validators/json_validators.py
+++ b/gdcdatamodel/validators/json_validators.py
@@ -46,5 +46,8 @@ class GDCJSONValidator(object):
                 keys = ['.'.join(error.path)] if error.path else []
                 if not keys:
                     keys = get_keys(error.message)
-                entity.record_error(error.message, keys=keys)
+                message = error.message
+                if error.context:
+                    message += ': {}'.format(' and '.join([c.message for c in error.context]))
+                entity.record_error(message, keys=keys)
             # additional validators go here


### PR DESCRIPTION
when a json schema is defined with `oneOf`, the error.message doesn't give useful information:
```
In [5]: validator = Draft4Validator({'properties': {'name': {'type': ['number', 'string'], 'oneOf': [{'enum': ['
   ...: abc']}, {'type': 'number'}]}}})

In [6]: for e in validator.iter_errors({'name': '123'}):
   ...:     print e.message
   ...:     print e.context
   ...:     
   ...:     
'123' is not valid under any of the given schemas
[<ValidationError: "'123' is not one of ['abc']">, <ValidationError: "'123' is not of type 'number'">]
```
This checks if there is any context for this error, and add the context to the error message.
So it's
```
'123' is not valid under any of the given schemas: '123' is not one of ['abc'] and '123' is not of type 'number'
```
instead of 
```
'123' is not valid under any of the given schemas
```
r? @NCI-GDC/ucdevs 