### PR TITLE
feat(case_cache): make case cache optional

### DIFF
--- a/gdcdatamodel/models/caching.py
+++ b/gdcdatamodel/models/caching.py
@@ -17,8 +17,14 @@ GDC datamodel.
 
 from cdisutils.log import get_logger
 from psqlgraph import Node, Edge
+from gdcdictionary import gdcdictionary
 
 logger = get_logger('gdcdatamodel')
+
+CACHE_CASES = (
+    True if not hasattr(gdcdictionary, 'settings')
+    else gdcdictionary.settings.get('enable_case_cache', True)
+)
 
 #: This variable contains the link name for the case shortcut
 #: association proxy


### PR DESCRIPTION
support disabling case cache hooks if that's explicitly specified in dictionary [settings](https://github.com/occ-data/envdictionary/blob/77848383969d28906856dd73e6ff5bb550c69968/gdcdictionary/schemas/_settings.yaml)

default to enable case cache if not specified
