### PR TITLE
feat(dict): add dictionaryutils

### DIFF
--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -17,7 +17,7 @@ propogate to all code that imports this package and MAY BREAK THINGS.
 
 from cdisutils.log import get_logger
 from collections import defaultdict
-from gdcdictionary import gdcdictionary as dictionary
+from dictionaryutils import dictionary
 from misc import FileReport                      # noqa
 from sqlalchemy.orm import configure_mappers
 from versioned_nodes import VersionedNode        # noqa
@@ -149,7 +149,6 @@ def PropertyFactory(name, schema, key=None):
     @pg_property(*python_types, enum=enum)
     def setter(self, val):
         self._set_property(key, val)
-
     setter.__name__ = name
 
     return setter

--- a/gdcdatamodel/validators/graph_validators.py
+++ b/gdcdatamodel/validators/graph_validators.py
@@ -1,4 +1,4 @@
-from gdcdictionary import gdcdictionary
+from dictionaryutils import dictionary as gdcdictionary
 import psqlgraph
 import sqlalchemy
 

--- a/gdcdatamodel/validators/json_validators.py
+++ b/gdcdatamodel/validators/json_validators.py
@@ -1,4 +1,4 @@
-from gdcdictionary import gdcdictionary
+from dictionaryutils import dictionary as gdcdictionary
 from jsonschema import Draft4Validator, RefResolver
 import re
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
         'jsonschema==2.5.1',
         'psqlgraph',
         'gdcdictionary',
+        'dictionaryutils',
         'cdisutils',
         'python-dateutil==2.4.2',
     ],
@@ -21,6 +22,7 @@ setup(
         'git+https://github.com/NCI-GDC/cdisutils.git@4a75cc05c7ba2174e70cca9c9ea7e93947f7a868#egg=cdisutils',
         'git+https://github.com/NCI-GDC/psqlgraph.git@7b5de7d56aa3159a9526940eb273579ddbf084ca#egg=psqlgraph',
         'git+https://github.com/NCI-GDC/gdcdictionary.git@6a8ddf96ad59b44163c5091d80e04245db4a6e9a#egg=gdcdictionary',
+        'git+https://github.com/uc-cdis/dictionaryutils.git@1.1.0#egg=dictionaryutils',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
[dictionaryutils.dictionary](https://github.com/uc-cdis/dictionaryutils/blob/master/dictionaryutils/dictionary.py) by default just load gdcdictionary, but allows rerun `init` to load with another dictionary
 The change is backward compatible
  