### PR TITLE
fix(version): bump dictionaryutils version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ setup(
         'pytz==2016.4',
         'graphviz==0.4.2',
         'jsonschema==2.5.1',
+        'python-dateutil==2.4.2',
         'psqlgraph',
         'gdcdictionary',
-        'dictionaryutils>=1.2.0,<2.0.0',
+        'dictionaryutils',
         'cdisutils',
-        'python-dateutil==2.4.2',
     ],
     package_data={
         "gdcdatamodel": [
@@ -22,6 +22,7 @@ setup(
         'git+https://github.com/NCI-GDC/cdisutils.git@4a75cc05c7ba2174e70cca9c9ea7e93947f7a868#egg=cdisutils',
         'git+https://github.com/NCI-GDC/psqlgraph.git@7b5de7d56aa3159a9526940eb273579ddbf084ca#egg=psqlgraph',
         'git+https://github.com/NCI-GDC/gdcdictionary.git@1.12#egg=gdcdictionary',
+        'git+https://github.com/uc-cdis/dictionaryutils.git@2.0.0#egg=dictionaryutils',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Root node and DataRelease node came with the introduction of 2.0. Also pinning third party library versions that way seems like you intend to install the package from pypi.