### PR TITLE
feat(file_reports): add report_data column to filereports

### DIFF
--- a/bin/destroy_and_setup_psqlgraph.py
+++ b/bin/destroy_and_setup_psqlgraph.py
@@ -73,6 +73,7 @@ def create_tables(host, user, password, database):
     versioned_nodes.Base.metadata.create_all(engine)
     submission.Base.metadata.create_all(engine)
     redaction.Base.metadata.create_all(engine)
+    misc.Base.metadata.create_all(engine)
 
 
 if __name__ == '__main__':

--- a/gdcdatamodel/models/misc.py
+++ b/gdcdatamodel/models/misc.py
@@ -1,6 +1,6 @@
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, String, Integer, Text, DateTime, BigInteger
-
+from sqlalchemy import Column, String, Integer, Text, DateTime, BigInteger, Index
 
 Base = declarative_base()
 
@@ -15,3 +15,9 @@ class FileReport(Base):
     streamed_bytes = Column('streamed_bytes', BigInteger)
     username = Column('username', String, index=True)
     requested_bytes = Column('requested_bytes', BigInteger)
+
+    report_data = Column(JSONB, nullable=True)
+
+    __table_args__ = (
+        Index("filereport_report_data_idx", "report_data", postgresql_using="gin",),
+    )


### PR DESCRIPTION
Adds report_data column to filereports table

Useful SQL queries
```sql
-- add new column to hold report data
ALTER TABLE public.filereport ADD COLUMN report_data jsonb;


-- add index to report_data column using gin (see: https://www.postgresql.org/docs/9.1/textsearch-indexes.html)
CREATE INDEX filereport_report_data_idx
  ON public.filereport
  USING gin
  (report_data);
```