### PR TITLE
TT-1072 set up tox for gdcdatamodel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ python:
 addons:
   postgresql: '9.4'
 
-before_script:
-    - yes | python setup.py install
-    - pip install -r dev-requirements.txt
-    - python bin/destroy_and_setup_psqlgraph.py
-    - pip freeze
-script: "py.test -v"
+install: "pip install tox-travis"
+
+script: "tox"

--- a/bin/destroy_and_setup_psqlgraph.py
+++ b/bin/destroy_and_setup_psqlgraph.py
@@ -19,7 +19,7 @@ def try_drop_test_data(user, database, root_user='postgres', host=''):
     try:
         create_stmt = 'DROP DATABASE "{database}"'.format(database=database)
         conn.execute(create_stmt)
-    except Exception, msg:
+    except Exception as msg:
         logging.warn("Unable to drop test data:" + str(msg))
 
     conn.close()
@@ -43,7 +43,7 @@ def setup_database(user, password, database, root_user='postgres',
     create_stmt = 'CREATE DATABASE "{database}"'.format(database=database)
     try:
         conn.execute(create_stmt)
-    except Exception, msg:
+    except Exception as msg:
         logging.warn('Unable to create database: {}'.format(msg))
 
     if not no_user:
@@ -56,7 +56,7 @@ def setup_database(user, password, database, root_user='postgres',
                         ''.format(database=database, password=password)
             conn.execute(perm_stmt)
             conn.execute("commit")
-        except Exception, msg:
+        except Exception as msg:
             logging.warn("Unable to add user:" + str(msg))
     conn.close()
 

--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -18,16 +18,16 @@ propogate to all code that imports this package and MAY BREAK THINGS.
 from cdisutils.log import get_logger
 from collections import defaultdict
 from dictionaryutils import dictionary
-from misc import FileReport                      # noqa
+from .misc import FileReport                      # noqa
 from sqlalchemy.orm import configure_mappers
-from versioned_nodes import VersionedNode        # noqa
+from .versioned_nodes import VersionedNode        # noqa
 
 import hashlib
-import versioned_nodes                           # noqa
-import notifications
-import submission
-import redaction
-import qcreport
+import gdcdatamodel.models.versioned_nodes                           # noqa
+import gdcdatamodel.models.notifications
+import gdcdatamodel.models.submission
+import gdcdatamodel.models.redaction
+import gdcdatamodel.models.qcreport
 
 from sqlalchemy import (
     event,

--- a/gdcdatamodel/models/versioned_nodes.py
+++ b/gdcdatamodel/models/versioned_nodes.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.dialects.postgres import ARRAY, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy import Column, Text, DateTime, BigInteger, text, Index
 from copy import copy
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist= py27, py3
+
+[testenv]
+deps= 
+    git+https://github.com/NCI-GDC/gdc-ng-models.git#egg=gdc_ng_models
+commands=
+    python setup.py install
+    pip install -r dev-requirements.txt
+    python bin/destroy_and_setup_psqlgraph.py
+    pip freeze            
+    py.test {posargs: -lvv test}


### PR DESCRIPTION
Not finished. 
Issues were in python2, gdcdatamodel/models/__init__.py was breaking in the get_links() function when running the bin/destroy_and_setup_psqlgraph.py
In python3, files were updated to resolve python2-related issues although issues are still related to the __init__.py file (path in line above) 

If destory_and_setup_psqlgraph.py line is commented from tox.ini, then errors are related to running the tests. 