### PR TITLE
fix(API-767): restrict updated_datetime changes

### DIFF
--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -242,9 +242,13 @@ def cls_inject_updated_datetime_hook(cls, updated_key="updated_datetime"):
 
     @event.listens_for(cls, 'before_update')
     def set_updated_datetimes(mapper, connection, target):
-        ts = target.get_session()._flush_timestamp.isoformat('T')
-        if 'updated_datetime' in target.props:
-            target._props['updated_datetime'] = ts
+        # SQLAlchemy fires this event when associations change, but we should
+        # only adjust the timestamp if the object itself was modified.
+        target_session = target.get_session()
+        if target_session.is_modified(target, include_collections=False):
+            ts = target_session._flush_timestamp.isoformat('T')
+            if updated_key in target.props:
+                target._props[updated_key] = ts
 
 
 def cls_inject_secondary_keys(cls, schema):

--- a/test/test_cache_related_cases.py
+++ b/test/test_cache_related_cases.py
@@ -223,3 +223,40 @@ class TestCacheRelatedCases(unittest.TestCase):
         with g.session_scope() as s:
             sample = g.nodes(md.Sample).one()
             assert sample._related_cases == [case2]
+
+    def test_preserve_timestamps(self):
+        """Confirm cache changes do not affect the case's timestamps."""
+        with g.session_scope() as s:
+            s.merge(md.Case('case_id_1'))
+
+        with g.session_scope() as s:
+            case = g.nodes(md.Case).one()
+            old_created_datetime = case.created_datetime
+            old_updated_datetime = case.updated_datetime
+
+            # Test addition of cache edges.
+            sample = md.Sample('sample_id_1')
+            portion = md.Portion('portion_id_1')
+            analyte = md.Analyte('analyte_id_1')
+            aliquot = md.Aliquot('aliquot_id_1')
+            sample.cases = [case]
+            portion.samples = [sample]
+            analyte.portions = [portion]
+            aliquot.analytes = [analyte]
+
+            sample2 = md.Sample('sample_id_2')
+            sample2.cases = [case]
+
+        with g.session_scope() as s:
+            case = g.nodes(md.Case).one()
+
+            # Exercise a few cache edge removal use cases as well.
+            analyte = g.nodes(md.Analyte).one()
+            sample2 = g.nodes(md.Sample).get('sample_id_2')
+            s.delete(analyte)
+            sample2.cases = []
+
+        with g.session_scope() as s:
+            case = g.nodes(md.Case).one()
+            assert case.created_datetime == old_created_datetime
+            assert case.updated_datetime == old_updated_datetime

--- a/test/test_datamodel.py
+++ b/test/test_datamodel.py
@@ -1,12 +1,43 @@
-import unittest
+from datetime import datetime
 import logging
+import unittest
+
+from psqlgraph import Edge, Node, PsqlGraphDriver
 from psqlgraph.exc import ValidationError
+
 from gdcdatamodel import models as md
 
 logging.basicConfig(level=logging.INFO)
 
 
 class TestDataModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        host = 'localhost'
+        user = 'test'
+        password = 'test'
+        database = 'automated_test'
+        cls.g = PsqlGraphDriver(host, user, password, database)
+
+        cls._clear_tables()
+
+    def tearDown(self):
+        self._clear_tables()
+
+    @classmethod
+    def _clear_tables(cls):
+        conn = cls.g.engine.connect()
+        conn.execute('commit')
+        for table in Node().get_subclass_table_names():
+            if table != Node.__tablename__:
+                conn.execute('delete from {}'.format(table))
+        for table in Edge.get_subclass_table_names():
+            if table != Edge.__tablename__:
+                conn.execute('delete from {}'.format(table))
+        conn.execute('delete from versioned_nodes')
+        conn.execute('delete from _voided_nodes')
+        conn.execute('delete from _voided_edges')
+        conn.close()
 
     def test_type_validation(self):
         f = md.File()
@@ -50,3 +81,55 @@ class TestDataModel(unittest.TestCase):
                 '_uncontended_link',
                 'samples',
             )
+
+    def test_created_datetime_hook(self):
+        """Test setting created/updated datetime when a node is created."""
+        time_before = datetime.utcnow().isoformat()
+
+        with self.g.session_scope() as s:
+            s.merge(md.Case('case1'))
+
+        time_after = datetime.utcnow().isoformat()
+
+        with self.g.session_scope():
+            case = self.g.nodes(md.Case).one()
+
+            # Compare against the time both before and after the write to
+            # ensure the comparison is fair.
+            assert time_before < case.created_datetime < time_after
+            assert time_before < case.updated_datetime < time_after
+
+    def test_updated_datetime_hook(self):
+        """Test setting updated datetime when a node is updated."""
+        with self.g.session_scope() as s:
+            s.merge(md.Case('case1'))
+
+        with self.g.session_scope():
+            case = self.g.nodes(md.Case).one()
+            old_created_datetime = case.created_datetime
+            old_updated_datetime = case.updated_datetime
+
+            case.primary_site = 'Kidney'
+
+        with self.g.session_scope():
+            updated_case = self.g.nodes(md.Case).one()
+            assert updated_case.created_datetime == old_created_datetime
+            assert updated_case.updated_datetime > old_updated_datetime
+
+    def test_no_datetime_update_for_new_edge(self):
+        """Verify new inbound edges do not affect a node's updated datetime."""
+        with self.g.session_scope() as s:
+            s.merge(md.Case('case1'))
+
+        with self.g.session_scope() as s:
+            case = self.g.nodes(md.Case).one()
+            old_created_datetime = case.created_datetime
+            old_updated_datetime = case.updated_datetime
+
+            sample = s.merge(md.Sample('sample1'))
+            case.samples.append(sample)
+
+        with self.g.session_scope():
+            updated_case = self.g.nodes(md.Case).one()
+            assert updated_case.created_datetime == old_created_datetime
+            assert updated_case.updated_datetime == old_updated_datetime


### PR DESCRIPTION
Only update `updated_datetime` if a node's own properties change. Don't update it when new edges are attached.

This prevents some potential issues with concurrent data submissions. Currently, if new children are created under the same parent concurrently, there can be conflicts updating the parent's `updated_datetime`. With this change, the `updated_datetime` won't be touched, so there won't be any conflict. I set up a parallel test in Sheepdog that submits a bunch of child nodes concurrently and verified that I was able to do so.

We should confirm that we want the business logic to work like this before we consider merging it, but in the meantime, the changes are here.