### PR TITLE
fix(edge_factory): use get_label instead of label

### DIFF
--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -592,7 +592,7 @@ def load_edges():
     for src_cls in Node.get_subclasses():
         cache_case = (
             not src_cls._dictionary['category'] in NOT_RELATED_CASES_CATEGORIES
-            or src_cls.label in ['annotation']
+            or src_cls.get_label() in ['annotation']
         )
 
         if not cache_case:
@@ -604,14 +604,14 @@ def load_edges():
             'required': False,
             'target_type': 'case',
             'label': 'relates_to',
-            'backref': '_related_{}'.format(src_cls.label),
+            'backref': '_related_{}'.format(src_cls.get_label()),
         }
 
         edge_name = parse_edge(
-            src_cls.label,
+            src_cls.get_label(),
             link['name'],
             'relates_to',
-            {'id': src_cls.label},
+            {'id': src_cls.get_label()},
             link,
         )
 

--- a/gdcdatamodel/models/indexes.py
+++ b/gdcdatamodel/models/indexes.py
@@ -45,7 +45,7 @@ def index_name(cls, description):
         logger.debug('Edge tablename {} too long, shortening'.format(oldname))
         name = 'index_{}_{}_{}'.format(
             hashlib.md5(py3_to_bytes(cls.__tablename__)).hexdigest()[:8],
-            ''.join([a[:4] for a in cls.label.split('_')])[:20],
+            ''.join([a[:4] for a in cls.get_label().split('_')])[:20],
             '_'.join([a[:8] for a in description.split('_')])[:25],
         )
 

--- a/migrations/update_case_cache_append_only.py
+++ b/migrations/update_case_cache_append_only.py
@@ -168,7 +168,7 @@ def seed_level_1(graph, cls):
             cls_to_case_edge_table=case_edge.__tablename__,
         )
 
-        print('Seeding {} through {}'.format(cls.label, case_edge.__name__))
+        print('Seeding {} through {}'.format(cls.get_label(), case_edge.__name__))
         graph.current_session().execute(statement)
 
 

--- a/migrations/update_legacy_states.py
+++ b/migrations/update_legacy_states.py
@@ -125,7 +125,7 @@ def print_cls_query_summary(graph):
     """Print breakdown of class counts to stdout"""
 
     cls_queries = {
-        cls.label: cls_query(graph, cls)
+        cls.get_label(): cls_query(graph, cls)
         for cls in CLS_WITH_PROJECT_ID & CLS_WITH_STATE
     }
 


### PR DESCRIPTION
`Node.label` and `Edge.label` is an `SQLAlchemy` `hybrid_property`. Previous versions for `SQLAlchemy` allows for resolving `hybrid_property` when called as a class property, but recent versions stopped this behavior (Not sure which version this happened) requiring class instances.