### PR TITLE
chore(version): bump version to 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 future
 SQLAlchemy==1.3.3
 git+https://github.com/NCI-GDC/psqlgraph.git@2.0.0#egg=psqlgraph
-git+https://github.com/NCI-GDC/gdcdictionary.git@2.0.0#egg=gdcdictionary
+git+https://github.com/NCI-GDC/gdcdictionary.git@2.1.0-alpha#egg=gdcdictionary
 git+https://github.com/NCI-GDC/gdc-ng-models.git@1.1.0#egg=gdc-ng-models
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='gdcdatamodel',
-    version="2.0.0",
+    version="2.1.0",
     packages=find_packages(),
     install_requires=[
         'pytz',


### PR DESCRIPTION
Bumps datamodels to latest dictionary, this helps validate that the changes in the dictionary can be used for table migrations and works ok with psqlgraph