### PR TITLE
DEV-941: use six.ensure_str to fix tag mismatch issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: bionic
 
 python:
   - 2.7
@@ -11,7 +12,7 @@ addons:
   postgresql: "13"
   apt:
     sources:
-      - sourceline: deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main 13
+      - sourceline: deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 13
         key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     packages:
       - postgresql-13

--- a/gdcdatamodel/models/versioning.py
+++ b/gdcdatamodel/models/versioning.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 
+import six
 from sqlalchemy import and_, event, select
 
 UUID_NAMESPACE_SEED = os.getenv("UUID_NAMESPACE_SEED", "86bb916a-24c5-48e4-8a46-5ea73a379d47")
@@ -16,7 +17,7 @@ class TagKeys:
 def __generate_hash(seed, label):
     namespace = UUID_NAMESPACE
     name = "{}-{}".format(seed, label)
-    return str(uuid.uuid5(namespace, name))
+    return six.ensure_str(str(uuid.uuid5(namespace, name)))
 
 
 def compute_tag(node):
@@ -26,8 +27,17 @@ def compute_tag(node):
     Returns:
         str: computed tag
     """
-    keys = [node.node_id if p == "node_id" else node.props[p] for p in node.tag_properties]
-    keys += sorted([p.dst.tag or compute_tag(p.dst) for p in node.edges_out if p.label != "relates_to"])
+    keys = [
+        six.ensure_str(node.node_id if p == "node_id" else node.props[p])
+        for p in node.tag_properties
+    ]
+    keys += sorted(
+        [
+            six.ensure_str(p.dst.tag or compute_tag(p.dst))
+            for p in node.edges_out
+            if p.label != "relates_to"
+        ]
+    )
     return __generate_hash(keys, node.label)
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     setup_requires=["setuptools_scm<6"],
     packages=find_packages(),
     install_requires=[
+        "six~=1.15",
         "pytz~=2020.1",
         "graphviz>=0.4.10,<0.17",
         "jsonschema~=3.2",

--- a/test/test_node_tagging.py
+++ b/test/test_node_tagging.py
@@ -1,7 +1,7 @@
 import pytest
 from psqlgraph import PsqlGraphDriver
 
-from gdcdatamodel.models import basic  # noqa
+from gdcdatamodel.models import basic, versioning  # noqa
 from test.helpers import create_tables, truncate
 
 
@@ -60,3 +60,4 @@ def test_1(create_samples, bg, node_id, tag, version):
         node = bg.nodes().get(node_id)
         assert node.tag == tag
         assert node.ver == version
+        assert versioning.compute_tag(node) == node.tag


### PR DESCRIPTION
Fixes issue where the function versioning.compute_tag generates generates different tag values for python2 and python3. The source of the difference was string representation in python2.

This blocks this PR https://github.com/NCI-GDC/biowcs/pull/221