### PR TITLE
remove parent tag caching

### DIFF
--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -17,8 +17,6 @@ propogate to all code that imports this package and MAY BREAK THINGS.
 import os
 import sys
 
-from sqlalchemy.orm.attributes import flag_modified
-
 try:
     from functools import lru_cache
 except ImportError:

--- a/gdcdatamodel/models/versioning.py
+++ b/gdcdatamodel/models/versioning.py
@@ -1,8 +1,14 @@
+import functools
 import os
 import uuid
 
 import six
 from sqlalchemy import and_, event, select
+try:
+    from functools import lru_cache
+except ImportError:
+    from functools32 import lru_cache
+
 
 UUID_NAMESPACE_SEED = os.getenv(
     "UUID_NAMESPACE_SEED", "86bb916a-24c5-48e4-8a46-5ea73a379d47"
@@ -22,6 +28,7 @@ def __generate_hash(seed, label):
     return six.ensure_str(str(uuid.uuid5(namespace, name)))
 
 
+@lru_cache(maxsize=None)
 def compute_tag(node):
     """Computes unique tag for given node
     Args:

--- a/gdcdatamodel/models/versioning.py
+++ b/gdcdatamodel/models/versioning.py
@@ -4,7 +4,9 @@ import uuid
 import six
 from sqlalchemy import and_, event, select
 
-UUID_NAMESPACE_SEED = os.getenv("UUID_NAMESPACE_SEED", "86bb916a-24c5-48e4-8a46-5ea73a379d47")
+UUID_NAMESPACE_SEED = os.getenv(
+    "UUID_NAMESPACE_SEED", "86bb916a-24c5-48e4-8a46-5ea73a379d47"
+)
 UUID_NAMESPACE = uuid.UUID("urn:uuid:{}".format(UUID_NAMESPACE_SEED), version=4)
 
 
@@ -33,7 +35,7 @@ def compute_tag(node):
     ]
     keys += sorted(
         [
-            six.ensure_str(p.dst.tag or compute_tag(p.dst))
+            six.ensure_str(compute_tag(p.dst))
             for p in node.edges_out
             if p.label != "relates_to"
         ]

--- a/test/unit/test_tagging.py
+++ b/test/unit/test_tagging.py
@@ -42,16 +42,22 @@ def test_multi_parent(sample_data):
 
     portion.samples.append(sample)
     portion.centers.append(center)
+
+    v.compute_tag.cache_clear()
     v_tag = v.compute_tag(portion)
     assert v_tag == "a9a67fae-d916-5843-bdf3-b7db0b7a82a2"
 
     # unlink
     portion.samples = []
     portion.centers = []
+
+    v.compute_tag.cache_clear()
     v_tag = v.compute_tag(portion)
     assert v_tag == "5776f97a-a58b-5900-83da-43cbc7105796"
 
     portion.centers.append(center)
     portion.samples.append(sample)
+
+    v.compute_tag.cache_clear()
     v_tag = v.compute_tag(portion)
     assert v_tag == "a9a67fae-d916-5843-bdf3-b7db0b7a82a2"


### PR DESCRIPTION
**Issue**: tag computation relies on the previously computed tag of the parent node, sometimes this value can be wrong even when trying to fix the generated tag, sometimes the old tag (wrong tag) is used instead of the newly fixed tags. This happened a lot during export of the v36 nodes.

**Fix**: remove the use of the parent's tag and force a complete recompute every time.