### PR TITLE
chore(pins): update dr32 final pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ decorator==4.4.2
     # via gdcdatamodel (setup.py)
 git+https://github.com/NCI-GDC/gdc-ng-models.git@1.5.2#egg=gdc-ng-models
     # via gdcdatamodel (setup.py)
-git+https://github.com/NCI-GDC/gdcdictionary.git@2.4.2-rc.1#egg=gdcdictionary
+git+https://github.com/NCI-GDC/gdcdictionary.git@2.4.2#egg=gdcdictionary
     # via gdcdatamodel (setup.py)
 graphviz==0.14.2
     # via gdcdatamodel (setup.py)
@@ -36,6 +36,7 @@ rstr==2.2.6
     # via psqlgraph
 six==1.15.0
     # via
+    #   gdcdatamodel (setup.py)
     #   jsonschema
     #   psqlgraph
     #   pyrsistent

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "jsonschema~=3.2",
         "pyrsistent<0.17.0",
         "decorator<=5.0.0",
-        "gdcdictionary @ git+https://github.com/NCI-GDC/gdcdictionary.git@2.4.2-rc.1#egg=gdcdictionary",
+        "gdcdictionary @ git+https://github.com/NCI-GDC/gdcdictionary.git@2.4.2#egg=gdcdictionary",
         "gdc-ng-models @ git+https://github.com/NCI-GDC/gdc-ng-models.git@1.5.2#egg=gdc-ng-models",
         "psqlgraph @ git+https://github.com/NCI-GDC/psqlgraph.git@3.4.0#egg=psqlgraph",
     ],


### PR DESCRIPTION
pip-compile 5.5.0 and python3.5 were used for this. Testing different
Python versions seemed to have mixed results. Using 3.5 caused the least
amount of changes which leads me to believe this is what we used last
time.