### PR TITLE
DEV-3557 Part 2 pre commit updates and tox fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 test-reports/
+report.xml
 
 # Jenkins
 .local/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,8 @@ variables:
 tox:
   parallel:
     matrix:
-      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
+      - LANGUAGE_VERSION: [python3.9]
+      #- LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
   services:
     - name: docker.osdc.io/ncigdc/ci-postgres-13:${BASE_CONTAINER_VERSION}
       alias: postgres

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,13 +22,7 @@ tox:
     POSTGRES_USER: test
     POSTGRES_PASSWORD: test
     POSTGRES_HOST_AUTH_METHOD: trust
-    PG_USER: test
-    PG_PASS: test
     PG_HOST: postgres
-    PG_INIT_SQL: |
-      create user test with superuser password 'test';
-      create database automated_test with owner test;
-      create database dev_models with owner test;
 
 # tox:
 #   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
 tox:
   parallel:
     matrix:
-      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
+      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11]
   services:
     - name: docker.osdc.io/ncigdc/ci-postgres-13:${BASE_CONTAINER_VERSION}
       alias: postgres

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,3 @@ tox:
     POSTGRES_DB: automated_test
     POSTGRES_HOST_AUTH_METHOD: trust
     PG_HOST: postgres
-    PG_INIT_SQL: |
-      create user test with superuser password 'test';
-      create database dev_models with owner test;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,37 +1,52 @@
 ---
-
 include:
   - project: nci-gdc/gitlab-templates
-    ref: 0.2.1
+    ref: master
     file:
-      - templates/global/full.yaml
-      - templates/python/full.yaml
-      - templates/common/python.yaml
+      - templates/artifacts/python-library.yaml
+variables:
+  LANGUAGE_VERSION: python3.9
 
 tox:
   parallel:
     matrix:
-      - BUILD_PY_VERSION: [python3.9, python3.10, python3.11]
-      #- BUILD_PY_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
+      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
   services:
-    - name: docker.osdc.io/ncigdc/ci-postgres-13:2.3.2
+    - name: docker.osdc.io/ncigdc/ci-postgres-13:${BASE_CONTAINER_VERSION}
       alias: postgres
   variables:
+    BASE_CONTAINER_VERSION: 3.1.0
     # these are for postgres docker
+    POSTGRES_DB: automated_test
+    POSTGRES_USER: test
+    POSTGRES_PASSWORD: test
     POSTGRES_HOST_AUTH_METHOD: trust
     PG_HOST: postgres
-    PG_INIT_SQL: |
-      create user test with superuser password 'test';
-      create database automated_test with owner test;
-      create database dev_models with owner test;
-  before_script:
-    - !reference [.load_github_key, script]
-    - pip install "tox<4"
-  script:
-    - tox -r -e py
 
-
-# used by release
-release:
-  before_script:
-    - git fetch --unshallow || true
+# tox:
+#   parallel:
+#     matrix:
+#       - BUILD_PY_VERSION: [python3.9, python3.10, python3.11]
+#       #- BUILD_PY_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
+#   services:
+#     - name: docker.osdc.io/ncigdc/ci-postgres-13:2.3.2
+#       alias: postgres
+#   variables:
+#     # these are for postgres docker
+#     POSTGRES_HOST_AUTH_METHOD: trust
+#     PG_HOST: postgres
+#     PG_INIT_SQL: |
+#       create user test with superuser password 'test';
+#       create database automated_test with owner test;
+#       create database dev_models with owner test;
+#   before_script:
+#     - !reference [.load_github_key, script]
+#     - pip install "tox<4"
+#   script:
+#     - tox -r -e py
+#
+#
+# # used by release
+# release:
+#   before_script:
+#     - git fetch --unshallow || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,8 +24,9 @@ tox:
     PG_HOST: postgres
     PG_INIT_SQL: |
       create user test with superuser password 'test';
-      create database automated_test with owner test;
       create database dev_models with owner test;
+
+    # create database automated_test with owner test;
 
 # tox:
 #   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,10 @@ tox:
     POSTGRES_PASSWORD: test
     POSTGRES_HOST_AUTH_METHOD: trust
     PG_HOST: postgres
+    PG_INIT_SQL: |
+      create user test with superuser password 'test';
+      create database automated_test with owner test;
+      create database dev_models with owner test;
 
 # tox:
 #   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,7 @@ variables:
 tox:
   parallel:
     matrix:
-      - LANGUAGE_VERSION: [python3.9]
-      #- LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
+      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
   services:
     - name: docker.osdc.io/ncigdc/ci-postgres-13:${BASE_CONTAINER_VERSION}
       alias: postgres
@@ -25,33 +24,3 @@ tox:
     PG_INIT_SQL: |
       create user test with superuser password 'test';
       create database dev_models with owner test;
-
-    # create database automated_test with owner test;
-
-# tox:
-#   parallel:
-#     matrix:
-#       - BUILD_PY_VERSION: [python3.9, python3.10, python3.11]
-#       #- BUILD_PY_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
-#   services:
-#     - name: docker.osdc.io/ncigdc/ci-postgres-13:2.3.2
-#       alias: postgres
-#   variables:
-#     # these are for postgres docker
-#     POSTGRES_HOST_AUTH_METHOD: trust
-#     PG_HOST: postgres
-#     PG_INIT_SQL: |
-#       create user test with superuser password 'test';
-#       create database automated_test with owner test;
-#       create database dev_models with owner test;
-#   before_script:
-#     - !reference [.load_github_key, script]
-#     - pip install "tox<4"
-#   script:
-#     - tox -r -e py
-#
-#
-# # used by release
-# release:
-#   before_script:
-#     - git fetch --unshallow || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,14 +17,15 @@ tox:
       alias: postgres
   variables:
     BASE_CONTAINER_VERSION: 3.1.0
-    # these are for postgres docker
+    # Use the defaults for POSTGRES_USER and POSTGRES_PASSWORD
+    #   This allows the admin user `postgres` with no password.
     POSTGRES_DB: automated_test
-    #POSTGRES_USER: postgres
-    #POSTGRES_PASSWORD: ""
-    #POSTGRES_USER: test
-    #POSTGRES_PASSWORD: test
     POSTGRES_HOST_AUTH_METHOD: trust
     PG_HOST: postgres
+    PG_INIT_SQL: |
+      create user test with superuser password 'test';
+      create database automated_test with owner test;
+      create database dev_models with owner test;
 
 # tox:
 #   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,10 @@ tox:
     BASE_CONTAINER_VERSION: 3.1.0
     # these are for postgres docker
     POSTGRES_DB: automated_test
-    POSTGRES_USER: test
-    POSTGRES_PASSWORD: test
+    #POSTGRES_USER: postgres
+    #POSTGRES_PASSWORD: ""
+    #POSTGRES_USER: test
+    #POSTGRES_PASSWORD: test
     POSTGRES_HOST_AUTH_METHOD: trust
     PG_HOST: postgres
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,9 @@ variables:
 tox:
   parallel:
     matrix:
-      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
+      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12]
+      # TODO: DEV-3571 required for python 3.13 to fix gdcdictionary
+      # - LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
   services:
     - name: docker.osdc.io/ncigdc/ci-postgres-13:${BASE_CONTAINER_VERSION}
       alias: postgres

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
 tox:
   parallel:
     matrix:
-      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11]
+      - LANGUAGE_VERSION: [python3.9, python3.10, python3.11, python3.12, python3.13]
   services:
     - name: docker.osdc.io/ncigdc/ci-postgres-13:${BASE_CONTAINER_VERSION}
       alias: postgres

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,8 @@ tox:
     POSTGRES_USER: test
     POSTGRES_PASSWORD: test
     POSTGRES_HOST_AUTH_METHOD: trust
+    PG_USER: test
+    PG_PASS: test
     PG_HOST: postgres
     PG_INIT_SQL: |
       create user test with superuser password 'test';

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,47 @@
 ---
 repos:
--   repo: git@github.com:Yelp/detect-secrets
-    rev: v1.4.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
-    -   id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: fix-encoding-pragma
+        args: [--remove]
+      - id: no-commit-to-branch
+        args: [--branch, develop, --branch, master, --pattern, release/.*]
+      - id: pretty-format-json
+        args: [--autofix]
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: forbid-crlf
+      - id: forbid-tabs
+        exclude: .(py|yaml|yml|tsv)$
+      - id: remove-crlf
+      - id: remove-tabs
+        exclude: .(py|yaml|yml|tsv)$
+  # - repo: https://github.com/astral-sh/ruff-pre-commit
+  #  rev: v0.11.8
+  #  hooks:
+  #    - id: ruff
+  #      args: [--fix]
+  #    - id: ruff-format
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.3
+    hooks:
+      - id: yamlfmt
+        args: [--mapping, '2', --sequence, '4', --offset, '2', --width, '80']
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.2
+    hooks:
+      - id: toml-sort
+        args: [--in-place]
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: [--baseline, .secrets.baseline]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -124,7 +124,7 @@
         "filename": ".gitlab-ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -149,5 +149,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-20T19:46:06Z"
+  "generated_at": "2025-06-20T20:33:49Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -149,5 +149,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-20T18:18:55Z"
+  "generated_at": "2025-06-20T19:08:24Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -144,10 +144,10 @@
         "filename": "test/test_admin_script.py",
         "hashed_secret": "90e391476614602bed80a0fb950a7c5111488a3b",
         "is_verified": false,
-        "line_number": 76,
+        "line_number": 87,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2025-06-20T20:33:49Z"
+  "generated_at": "2025-06-23T14:45:48Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,16 +118,6 @@
     }
   ],
   "results": {
-    ".gitlab-ci.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".gitlab-ci.yml",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 23,
-        "is_secret": false
-      }
-    ],
     "migrations/update_legacy_states.py": [
       {
         "type": "Secret Keyword",
@@ -149,5 +139,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-23T14:56:31Z"
+  "generated_at": "2025-06-23T15:32:21Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -130,7 +130,7 @@
         "filename": ".gitlab-ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 24
       }
     ],
     "migrations/update_legacy_states.py": [
@@ -154,5 +154,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-23T16:28:04Z"
+  "generated_at": "2025-06-23T19:11:06Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -124,7 +124,7 @@
         "filename": ".gitlab-ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 22,
         "is_secret": false
       }
     ],
@@ -149,5 +149,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-20T19:08:24Z"
+  "generated_at": "2025-06-20T19:46:06Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,9 +115,24 @@
       "pattern": [
         "^.secrets.baseline$"
       ]
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "pattern": [
+        "(fakesecret|unset)"
+      ]
     }
   ],
   "results": {
+    ".gitlab-ci.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".gitlab-ci.yml",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
     "migrations/update_legacy_states.py": [
       {
         "type": "Secret Keyword",
@@ -139,5 +154,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-23T15:32:21Z"
+  "generated_at": "2025-06-23T16:28:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -144,10 +144,10 @@
         "filename": "test/test_admin_script.py",
         "hashed_secret": "90e391476614602bed80a0fb950a7c5111488a3b",
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 86,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2025-06-23T14:45:48Z"
+  "generated_at": "2025-06-23T14:56:31Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -124,15 +124,6 @@
     }
   ],
   "results": {
-    ".gitlab-ci.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".gitlab-ci.yml",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 24
-      }
-    ],
     "migrations/update_legacy_states.py": [
       {
         "type": "Secret Keyword",
@@ -154,5 +145,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-23T19:11:06Z"
+  "generated_at": "2025-06-23T20:03:20Z"
 }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,9 +4,9 @@ html='html/gdc_docs.html'
 all: pdf
 
 pdf:
-	python bin/schemata_to_graphviz.py
+    python bin/schemata_to_graphviz.py
 
 .PHONY: pdf
 
 clean:
-	rm $(pdf) $(html)
+    rm $(pdf) $(html)

--- a/examples/jupyter_example.ipynb
+++ b/examples/jupyter_example.ipynb
@@ -1,92 +1,92 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# PG_USER= PG_HOST= PG_DATABASE= PG_PASSWORD=   jupyter notebook\n",
-    "\n",
-    "import psqlgraph\n",
-    "import os\n",
-    "\n",
-    "from graphviz import Digraph\n",
-    "from IPython.display import display\n",
-    "from gdcdatamodel.models import *\n",
-    "from gdcdatamodel.viz import create_graphviz\n",
-    "from psqlgraph import PsqlGraphDriver, Node, Edge\n",
-    "\n",
-    "HOST = os.environ.get('PG_HOST')\n",
-    "USER = os.environ.get('PG_USER')\n",
-    "DATABASE = os.environ.get('PG_DATABASE')\n",
-    "PASSWORD = os.environ.get('PG_PASSWORD')\n",
-    "\n",
-    "g = psqlgraph.PsqlGraphDriver(HOST, USER, PASSWORD, DATABASE)\n",
-    "print('Ready!')"
-   ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "# PG_USER= PG_HOST= PG_DATABASE= PG_PASSWORD=   jupyter notebook\n",
+        "\n",
+        "import psqlgraph\n",
+        "import os\n",
+        "\n",
+        "from graphviz import Digraph\n",
+        "from IPython.display import display\n",
+        "from gdcdatamodel.models import *\n",
+        "from gdcdatamodel.viz import create_graphviz\n",
+        "from psqlgraph import PsqlGraphDriver, Node, Edge\n",
+        "\n",
+        "HOST = os.environ.get('PG_HOST')\n",
+        "USER = os.environ.get('PG_USER')\n",
+        "DATABASE = os.environ.get('PG_DATABASE')\n",
+        "PASSWORD = os.environ.get('PG_PASSWORD')\n",
+        "\n",
+        "g = psqlgraph.PsqlGraphDriver(HOST, USER, PASSWORD, DATABASE)\n",
+        "print('Ready!')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false,
+        "scrolled": false
+      },
+      "outputs": [],
+      "source": [
+        "with g.session_scope():\n",
+        "    cases = g.nodes(Case).subq_path('samples').limit(1).all()\n",
+        "    case_neighbors = [edge.src for case in cases for edge in case.edges_in]\n",
+        "    samples = [sample for case in cases for sample in case.samples]\n",
+        "    portions = [portion for sample in samples for portion in sample.portions]\n",
+        "    analytes = [analyte for portion in portions for analyte in portion.analytes]\n",
+        "    aliquots = [aliquot for analyte in analytes for aliquot in analyte.aliquots]\n",
+        "    nodes = cases + case_neighbors + samples + portions + analytes + aliquots\n",
+        "    display(create_graphviz(nodes))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": true
+      },
+      "outputs": [],
+      "source": [
+        "## You may need to do something like the following if the above display() command does not render a graph for you\n",
+        "\n",
+        "# from IPython.display import Image \n",
+        "\n",
+        "# d = create_graphviz(nodes)\n",
+        "# d.format = 'png'\n",
+        "# d.render()\n",
+        "\n",
+        "# Image(filename='Digraph.gv.png')"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 2",
+      "language": "python",
+      "name": "python2"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 2
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython2",
+      "version": "2.7.10"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "with g.session_scope():\n",
-    "    cases = g.nodes(Case).subq_path('samples').limit(1).all()\n",
-    "    case_neighbors = [edge.src for case in cases for edge in case.edges_in]\n",
-    "    samples = [sample for case in cases for sample in case.samples]\n",
-    "    portions = [portion for sample in samples for portion in sample.portions]\n",
-    "    analytes = [analyte for portion in portions for analyte in portion.analytes]\n",
-    "    aliquots = [aliquot for analyte in analytes for aliquot in analyte.aliquots]\n",
-    "    nodes = cases + case_neighbors + samples + portions + analytes + aliquots\n",
-    "    display(create_graphviz(nodes))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "## You may need to do something like the following if the above display() command does not render a graph for you\n",
-    "\n",
-    "# from IPython.display import Image \n",
-    "\n",
-    "# d = create_graphviz(nodes)\n",
-    "# d.format = 'png'\n",
-    "# d.render()\n",
-    "\n",
-    "# Image(filename='Digraph.gv.png')"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 2",
-   "language": "python",
-   "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/gdcdatamodel/models/__init__.py
+++ b/gdcdatamodel/models/__init__.py
@@ -12,6 +12,7 @@ propogate to all code that imports this package and MAY BREAK THINGS.
 - jsm
 
 """
+
 import hashlib
 import logging
 import os
@@ -194,7 +195,6 @@ def cls_inject_versioned_nodes_lookup(cls):
         :returns: A SQLAlchemy query for node versions.
 
         """
-
         session = self.get_session()
         if not session:
             raise RuntimeError(
@@ -204,7 +204,6 @@ def cls_inject_versioned_nodes_lookup(cls):
 
     def get_versions(self, session):
         """Returns a query for node versions given a session."""
-
         return (
             session.query(VersionedNode)
             .filter(VersionedNode.node_id == self.node_id)
@@ -269,7 +268,6 @@ def cls_inject_secondary_keys(cls, schema):
            objects
 
     """
-
     unique_keys = schema.get("uniqueKeys", [])
     cls.__pg_secondary_keys = [keys for keys in unique_keys if "id" not in keys]
 
@@ -316,7 +314,6 @@ def cls_inject_secondary_keys(cls, schema):
 
 def NodeFactory(_id, schema, node_cls=Node, package_namespace=None):
     """Returns a node class given a schema."""
-
     name = get_class_name_from_id(_id)
     links = get_links(schema)
 
@@ -354,7 +351,6 @@ def NodeFactory(_id, schema, node_cls=Node, package_namespace=None):
         Returns:
             bool: True if node can be tagged
         """
-
         return self.tag_builder_config.is_taggable(self)
 
     def get_tag_property_values(self):
@@ -377,7 +373,7 @@ def NodeFactory(_id, schema, node_cls=Node, package_namespace=None):
 
     @property
     def is_latest(self):
-        """latest version of the node based on tagging
+        """Latest version of the node based on tagging
 
         Returns:
             bool: True if its the latest version otherwise false
@@ -386,7 +382,7 @@ def NodeFactory(_id, schema, node_cls=Node, package_namespace=None):
 
     @property
     def ver(self):
-        """node version number based on tagging
+        """Node version number based on tagging
 
         versions are computed during save or via an external script
         Returns:
@@ -468,7 +464,7 @@ def NodeFactory(_id, schema, node_cls=Node, package_namespace=None):
             __tablename__=get_class_tablename_from_id(_id),
             __label__=_id,
             id=node_id,
-            **attributes
+            **attributes,
         ),
     )
 
@@ -498,7 +494,6 @@ def generate_edge_tablename(src_label, label, dst_label):
     is rather an undesirable workaround. - jsm
 
     """
-
     tablename = "edge_{}{}{}".format(
         src_label.replace("_", ""),
         label.replace("_", ""),
@@ -511,7 +506,7 @@ def generate_edge_tablename(src_label, label, dst_label):
         oldname = tablename
         logger.debug(f"Edge tablename {oldname} too long, shortening")
         tablename = "edge_{}_{}".format(
-            hashlib.md5(py3_to_bytes(tablename)).hexdigest()[:8],
+            hashlib.md5(py3_to_bytes(tablename), usedforsecurity=False).hexdigest()[:8],
             "{}{}{}".format(
                 "".join([a[:2] for a in src_label.split("_")])[:10],
                 "".join([a[:2] for a in label.split("_")])[:7],
@@ -668,7 +663,6 @@ def parse_edge(
     :returns: The outbound name of the edge
 
     """
-
     dst_label = link["target_type"]
     backref = link["backref"]
 
@@ -707,9 +701,7 @@ def load_edges(dictionary, node_cls=Node, edge_cls=Edge, package_namespace=None)
     { <link name>: {'backref': <backref name>, 'type': <source type> } }
 
     """
-
     for src_label, subschema in dictionary.schema.items():
-
         src_cls = node_cls.get_subclass(src_label)
         if not src_cls:
             raise RuntimeError(f"No source class labeled {src_label}")
@@ -770,7 +762,6 @@ def inject_pg_backrefs(dictionary, node_cls):
         { <link name>: {'name': <backref name>, 'src_type': <source type> } }
 
     """
-
     for src_label, subschema in dictionary.schema.items():
         for name, link in get_links(subschema).items():
             dst_cls = node_cls.get_subclass(link["target_type"])
@@ -795,7 +786,6 @@ def inject_pg_edges(node_cls):
         :returns: None, cls is mutated
 
         """
-
         for name, link in cls._pg_links.items():
             cls._pg_edges[name] = {
                 "backref": link["backref"],
@@ -810,7 +800,6 @@ def inject_pg_edges(node_cls):
         :returns: None, cls is mutated
 
         """
-
         for name, backref in cls._pg_backrefs.items():
             cls._pg_edges[name] = {
                 "backref": backref["name"],
@@ -833,7 +822,6 @@ def load_dictionary(dictionary=None, package_namespace=None):
         AssertionError: If method is called more than maxsize of the lru_cache, which is 10. This method should only
             be called once
     """
-
     if dictionary is None:
         from gdcdictionary import gdcdictionary
 

--- a/gdcdatamodel/models/indexes.py
+++ b/gdcdatamodel/models/indexes.py
@@ -31,7 +31,6 @@ def index_name(cls, description):
     another rather an undesirable workaround. - jsm
 
     """
-
     name = f"index_{cls.__tablename__}_{description}"
 
     # If the name is too long, prepend it with the first 8 hex of it's hash
@@ -40,7 +39,9 @@ def index_name(cls, description):
         oldname = index_name
         logger.debug(f"Edge tablename {oldname} too long, shortening")
         name = "index_{}_{}_{}".format(
-            hashlib.md5(py3_to_bytes(cls.__tablename__)).hexdigest()[:8],
+            hashlib.md5(
+                py3_to_bytes(cls.__tablename__), usedforsecurity=False
+            ).hexdigest()[:8],
             "".join([a[:4] for a in cls.get_label().split("_")])[:20],
             "_".join([a[:8] for a in description.split("_")])[:25],
         )
@@ -59,7 +60,6 @@ def get_secondary_key_indexes(cls):
     - lower(cls._props[key].astext)
 
     """
-
     #: use text_pattern_ops, allows LIKE statements not starting with %
     index_op = "text_pattern_ops"
     secondary_keys = {key for pair in cls.__pg_secondary_keys for key in pair}
@@ -87,6 +87,5 @@ def get_secondary_key_indexes(cls):
 
 def cls_add_indexes(cls, indexes):
     """Add indexes to given class"""
-
     for i in indexes:
         cls.__table__.append_constraint(i)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ target-version = [
 include = '\.pyi?$'
 
 [tool.coverage.html]
-title = "gdcdatamodel coverage report"
-directory = "htmlcov"
+directory = "docs/htmlcov"
 show_contexts = true
+title = "gdcdatamodel coverage report"
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ source = ["gdcdatamodel"]
 
 [tool.isort]
 profile = "black"
-known_third_party = ["addict", "authutils", "cdiserrors", "cdislogging", "ciso8601", "deepdiff", "defusedcsv", "dotenv", "envelopes", "flask", "flask_cors", "gdc_ng_models", "gdcdictionary", "httmock", "indexclient", "indexd", "indexd_test_utils", "jsonschema", "mock", "pkg_resources", "psqlgraph", "pytest", "requests", "setuptools", "simplejson", "six", "sqlalchemy", "yaml"]
+known_third_party = ["addict", "authutils", "cdiserrors", "cdislogging", "ciso8601", "deepdiff", "defusedcsv", "dotenv", "envelopes", "flask", "flask_cors", "gdc_ng_models", "gdcdictionary", "httmock", "importlib", "indexclient", "indexd", "indexd_test_utils", "jsonschema", "mock", "psqlgraph", "pytest", "requests", "setuptools", "simplejson", "six", "sqlalchemy", "yaml"]
 known_first_party = ["gdcdatamodel", "setup_batch", "setup_notifications", "setup_psqlgraph", "setup_redactionslog", "setup_report", "setup_study_data", "setup_transactionlogs"]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,33 @@
 [build-system]
 requires = [
-    "setuptools>=42",
-    "wheel",
-    "setuptools_scm[toml]>=3.4"
+  "setuptools>=42",
+  "wheel",
+  "setuptools_scm[toml]>=3.4"
 ]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-local_scheme = "no-local-version"
-write_to = "gdcdatamodel/_version.py"
 
 [tool.black]
 line-length = 88
 target-version = [
-    'py39',
+  'py39'
 ]
 include = '\.pyi?$'
-
-[tool.coverage.run]
-branch = true
-context = "unit tests"
-source = ["gdcdatamodel"]
 
 [tool.coverage.html]
 title = "gdcdatamodel coverage report"
 directory = "htmlcov"
 show_contexts = true
 
+[tool.coverage.run]
+branch = true
+context = "unit tests"
+source = ["gdcdatamodel"]
+
 [tool.isort]
 profile = "black"
 known_third_party = ["addict", "authutils", "cdiserrors", "cdislogging", "ciso8601", "deepdiff", "defusedcsv", "dotenv", "envelopes", "flask", "flask_cors", "gdc_ng_models", "gdcdictionary", "httmock", "indexclient", "indexd", "indexd_test_utils", "jsonschema", "mock", "pkg_resources", "psqlgraph", "pytest", "requests", "setuptools", "simplejson", "six", "sqlalchemy", "yaml"]
 known_first_party = ["gdcdatamodel", "setup_batch", "setup_notifications", "setup_psqlgraph", "setup_redactionslog", "setup_report", "setup_study_data", "setup_transactionlogs"]
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"
+write_to = "gdcdatamodel/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
     ],
     license="Apache",
     packages=find_packages(),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,21 +1,24 @@
-"""
-gdcdatamodel.test.conftest
+"""gdcdatamodel.test.conftest
 ----------------------------------
 
 pytest setup for gdcdatamodel tests
 """
+
+import logging
 import random
 import unittest
 import uuid
-from test import helpers, models as test_models
 
 import pkg_resources
 import pytest
+import sqlalchemy
 import yaml
-from psqlgraph import PsqlGraphDriver, mocks
-from sqlalchemy import create_engine
+from psqlgraph import PsqlGraphDriver, mocks, psql
+from sqlalchemy import create_engine, engine
 
 from gdcdatamodel import models
+from test import helpers
+from test import models as test_models
 
 models.load_dictionary(test_models.BasicDictionary, "basic")
 from gdcdatamodel.models import basic  # noqa
@@ -26,11 +29,52 @@ def db_config():
     return helpers.DB_CONFIG
 
 
+@pytest.fixture(scope="session", autouse=True)
+def setup_databases():
+    """Setup the user and database"""
+    print("Setting up test databases")
+    root_user = helpers.DB_CONFIG_ADMIN["user"]
+    host = helpers.DB_CONFIG_ADMIN["host"]
+    engine = sqlalchemy.create_engine(f"postgresql://{root_user}@{host}/postgres")
+    conn = engine.connect()
+    _create_db_and_role(conn, "dev_models", "test", "test")
+    _create_db_and_role(conn, "automated_test", "test", "test")
+    conn.close()
+
+
+def _create_db_and_role(conn, database: str, user: str, password: str):
+    result = conn.execute(
+        sqlalchemy.text("SELECT 1 FROM pg_database WHERE datname = :database"),
+        database=database,
+    )
+    assert isinstance(result, engine.result.ResultProxy)
+
+    row: engine.result.RowProxy = result.fetchone()
+    assert isinstance(row, engine.result.RowProxy)
+
+    # When the database does not exist, create it.
+    if not row[0]:
+        create_stmt = f'CREATE DATABASE "{database}"'
+        conn.execute(create_stmt)
+
+    try:
+        user_stmt = "CREATE USER {user} WITH PASSWORD '{password}'".format(
+            user=user, password=password
+        )
+        conn.execute(user_stmt)
+
+        perm_stmt = "GRANT ALL PRIVILEGES ON DATABASE {database} to {password}".format(
+            database=database, password=password
+        )
+        conn.execute(perm_stmt)
+        conn.execute("commit")
+    except Exception as msg:
+        logging.warning("Unable to add user:" + str(msg))
+
+
 @pytest.fixture(scope="session")
 def tables_created(db_config):
-    """
-    Create necessary tables
-    """
+    """Create necessary tables"""
     engine = create_engine(
         "postgres://{user}:{pwd}@{host}/{db}".format(
             user=db_config["user"],
@@ -50,15 +94,12 @@ def tables_created(db_config):
 @pytest.fixture(scope="session")
 def g(db_config, tables_created):
     """Fixture for database driver"""
-
     return PsqlGraphDriver(**db_config)
 
 
 @pytest.fixture(scope="class")
 def db_class(request, g):
-    """
-    Sets g property on a test class
-    """
+    """Sets g property on a test class"""
     request.cls.g = g
 
 
@@ -86,7 +127,6 @@ def indexes(g):
 @pytest.fixture()
 def redacted_fixture(g):
     """Creates a redacted log entry"""
-
     with g.session_scope() as sxn:
         log = models.redaction.RedactionLog()
         log.initiated_by = "TEST"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -165,8 +165,6 @@ class BaseTestCase(unittest.TestCase):
 
 @pytest.fixture(scope="module")
 def sample_data():
-    # with pkg_resources.resource_stream(__name__, "schema/data/sample.yaml") as f:
-    #    graph = yaml.safe_load(f)
     with resources.files("test").joinpath("schema/data/sample.yaml").open("rb") as f:
         graph = yaml.safe_load(f)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -50,10 +50,7 @@ def _create_db_and_role(conn, database: str, user: str, password: str):
     assert isinstance(result, engine.result.ResultProxy)
 
     row: engine.result.RowProxy = result.fetchone()
-    assert isinstance(row, engine.result.RowProxy)
-
-    # When the database does not exist, create it.
-    if not row[0]:
+    if row is None:
         create_stmt = f'CREATE DATABASE "{database}"'
         conn.execute(create_stmt)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -169,7 +169,7 @@ class BaseTestCase(unittest.TestCase):
 def sample_data():
     # with pkg_resources.resource_stream(__name__, "schema/data/sample.yaml") as f:
     #    graph = yaml.safe_load(f)
-    with resources.files(__name__).joinpath("schema/data/sample.yaml").open("rb") as f:
+    with resources.files("test").joinpath("schema/data/sample.yaml").open("rb") as f:
         graph = yaml.safe_load(f)
 
     f = mocks.GraphFactory(basic, test_models.BasicDictionary)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -51,6 +51,7 @@ def _create_db_and_role(conn, database: str, user: str, password: str):
 
     row: engine.result.RowProxy = result.fetchone()
     if row is None:
+        conn.execute("commit")  # exit any transaction you may be in.
         create_stmt = f'CREATE DATABASE "{database}"'
         conn.execute(create_stmt)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,8 +8,8 @@ import logging
 import random
 import unittest
 import uuid
+from importlib import resources
 
-import pkg_resources
 import pytest
 import sqlalchemy
 import yaml
@@ -167,7 +167,9 @@ class BaseTestCase(unittest.TestCase):
 
 @pytest.fixture(scope="module")
 def sample_data():
-    with pkg_resources.resource_stream(__name__, "schema/data/sample.yaml") as f:
+    # with pkg_resources.resource_stream(__name__, "schema/data/sample.yaml") as f:
+    #    graph = yaml.safe_load(f)
+    with resources.files(__name__).joinpath("schema/data/sample.yaml").open("rb") as f:
         graph = yaml.safe_load(f)
 
     f = mocks.GraphFactory(basic, test_models.BasicDictionary)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -68,3 +68,10 @@ DB_CONFIG = {
     "password": os.getenv("PG_PASS", "test"),
     "database": os.getenv("PG_NAME", "automated_test"),
 }
+
+DB_CONFIG_ADMIN = {
+    "host": os.getenv("PG_HOST", "localhost"),
+    "user": "postgres",
+    "password": None,
+    "database": os.getenv("PG_NAME", "automated_test"),
+}

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,4 +1,5 @@
 import os
+
 import psqlgraph
 from psqlgraph import create_all, ext
 
@@ -6,9 +7,7 @@ from gdcdatamodel import models
 
 
 def truncate(engine, namespace=None):
-    """
-    Remove data from existing tables
-    """
+    """Remove data from existing tables"""
     abstract_node = psqlgraph.Node
     abstract_edge = psqlgraph.Edge
     if namespace:
@@ -29,10 +28,7 @@ def truncate(engine, namespace=None):
 
 
 def create_tables(engine, namespace=None):
-    """
-    create a table
-    """
-
+    """Create a table"""
     base = psqlgraph.base.ORMBase
     if namespace:
         base = ext.get_orm_base(namespace)
@@ -52,7 +48,6 @@ def create_ng_tables(engine):
 
 
 def truncate_ng_tables(conn):
-
     # Extend this list as needed
     ng_models_metadata = [
         models.versioned_nodes.Base.metadata,
@@ -68,8 +63,8 @@ def truncate_ng_tables(conn):
 
 
 DB_CONFIG = {
-        "host": os.getenv("PG_HOST", "localhost"),
-        "user": os.getenv("PG_HOST", "test"),
-        "password": os.getenv("PG_PASS", "test"),
-        "database": os.getenv("PG_NAME","automated_test"),
+    "host": os.getenv("PG_HOST", "localhost"),
+    "user": os.getenv("PG_USER", "test"),
+    "password": os.getenv("PG_PASS", "test"),
+    "database": os.getenv("PG_NAME", "automated_test"),
 }

--- a/test/models.py
+++ b/test/models.py
@@ -1,9 +1,10 @@
-import pkg_resources
+from importlib import resources
+
 import yaml
 
 
 def _load(name):
-    with pkg_resources.resource_stream(__name__, name) as f:
+    with resources.files("test").joinpath(name).open("rb") as f:
         return yaml.safe_load(f)
 
 

--- a/test/test_admin_script.py
+++ b/test/test_admin_script.py
@@ -5,20 +5,32 @@ from sqlalchemy.exc import ProgrammingError
 
 from gdcdatamodel import gdc_postgres_admin as pgadmin
 from gdcdatamodel import models
-
 from test import helpers
 
 
-def get_base_args(host=helpers.DB_CONFIG.get('host'), database=helpers.DB_CONFIG.get('database'), namespace=None):
-    return ["-H", host, "-U", helpers.DB_CONFIG.get('user'), "-D", database, "-N", namespace or ""]
+def get_base_args(
+    host=helpers.DB_CONFIG.get("host"),
+    database=helpers.DB_CONFIG.get("database"),
+    namespace=None,
+):
+    return [
+        "-H",
+        host,
+        "-U",
+        helpers.DB_CONFIG.get("user"),
+        "-D",
+        database,
+        "-N",
+        namespace or "",
+    ]
 
 
 def get_admin_driver(db_config, namespace=None):
-
     # assumes no password postgres user
     g = psqlgraph.PsqlGraphDriver(
         package_namespace=namespace,
-        host=db_config["host"],
+        # host=db_config["host"],
+        host="localhost",
         user="postgres",
         password=None,
         database=db_config["database"],
@@ -71,16 +83,13 @@ def valid_read_access_fn(g):
 
 @pytest.fixture()
 def add_test_database_user(db_config):
-
     dummy_user = "pytest_dummy"
     dummy_pwd = "pytest_du33y"
 
     g = get_admin_driver(db_config)
 
     try:
-        g.engine.execute(
-            f"CREATE USER {dummy_user} WITH PASSWORD '{dummy_pwd}'"
-        )
+        g.engine.execute(f"CREATE USER {dummy_user} WITH PASSWORD '{dummy_pwd}'")
         g.engine.execute(f"GRANT USAGE ON SCHEMA public TO {dummy_user}")
         yield dummy_user, dummy_pwd
     finally:
@@ -94,7 +103,6 @@ def test_create_tables(db_config, namespace):
         db_config (dict[str,str]): db connection config
         namespace (str): module namespace, None for default
     """
-
     # simulate loading a different dictionary
     if namespace:
         models.load_dictionary(dictionary=None, package_namespace=namespace)
@@ -146,7 +154,6 @@ def test_grant_permissions(
     invalid_permission_fn,
     valid_permission_fn,
 ):
-
     # simulate loading a different dictionary
     if namespace:
         models.load_dictionary(dictionary=None, package_namespace=namespace)
@@ -186,7 +193,6 @@ def test_revoke_permissions(
     invalid_permission_fn,
     valid_permission_fn,
 ):
-
     # simulate loading a different dictionary
     if namespace:
         models.load_dictionary(dictionary=None, package_namespace=namespace)

--- a/test/test_admin_script.py
+++ b/test/test_admin_script.py
@@ -29,8 +29,7 @@ def get_admin_driver(db_config, namespace=None):
     # assumes no password postgres user
     g = psqlgraph.PsqlGraphDriver(
         package_namespace=namespace,
-        # host=db_config["host"],
-        host="localhost",
+        host=db_config["host"],
         user="postgres",
         password=None,
         database=db_config["database"],

--- a/test/test_gdc_postgres_admin.py
+++ b/test/test_gdc_postgres_admin.py
@@ -1,6 +1,4 @@
-"""
-Tests for gdcdatamodel.gdc_postgres_admin module
-"""
+"""Tests for gdcdatamodel.gdc_postgres_admin module"""
 
 import logging
 import unittest
@@ -10,20 +8,21 @@ from sqlalchemy.exc import ProgrammingError
 
 from gdcdatamodel import gdc_postgres_admin as pgadmin
 from gdcdatamodel import models
-
 from test import helpers
 
 logging.basicConfig()
 
 
 class TestGDCPostgresAdmin(unittest.TestCase):
-
     logger = logging.getLogger("TestGDCPostgresAdmin")
     logger.setLevel(logging.INFO)
 
-    host = helpers.DB_CONFIG.get('host')
-    user = helpers.DB_CONFIG.get('user')
-    database = helpers.DB_CONFIG.get('database')
+    host = helpers.DB_CONFIG_ADMIN.get("host")
+    user = helpers.DB_CONFIG_ADMIN.get("user")
+    password = helpers.DB_CONFIG_ADMIN.get("password")
+
+    # using the test database with the postgres admin user
+    database = helpers.DB_CONFIG.get("database")
 
     base_args = [
         "-H",
@@ -34,9 +33,11 @@ class TestGDCPostgresAdmin(unittest.TestCase):
         database,
     ]
 
-    g = PsqlGraphDriver(host, user, "", database)
+    # TODO: it looks like the graph and root_con_str were to be done by the owner of the database.
+    g = PsqlGraphDriver(host, user, password, database)
+
     root_con_str = "postgres://{user}:{pwd}@{host}/{db}".format(
-        user=user, host=host, pwd="", db=database
+        user=user, host=host, pwd=password, db=database
     )
     engine = pgadmin.create_engine(root_con_str)
 
@@ -85,7 +86,6 @@ class TestGDCPostgresAdmin(unittest.TestCase):
 
     def test_create_single(self):
         """Test simple table creation"""
-
         pgadmin.main(
             pgadmin.get_parser().parse_args(
                 ["graph-create", "--delay", "1", "--retries", "0"] + self.base_args
@@ -96,7 +96,6 @@ class TestGDCPostgresAdmin(unittest.TestCase):
 
     def test_create_double(self):
         """Test idempotency of table creation"""
-
         pgadmin.main(
             pgadmin.get_parser().parse_args(
                 ["graph-create", "--delay", "1", "--retries", "0"] + self.base_args
@@ -107,7 +106,6 @@ class TestGDCPostgresAdmin(unittest.TestCase):
 
     def test_priv_grant_read(self):
         """Test ability to grant read but not write privs"""
-
         self.create_all_tables()
 
         try:
@@ -143,7 +141,6 @@ class TestGDCPostgresAdmin(unittest.TestCase):
 
     def test_priv_grant_write(self):
         """Test ability to grant read/write privs"""
-
         self.create_all_tables()
 
         try:
@@ -170,7 +167,6 @@ class TestGDCPostgresAdmin(unittest.TestCase):
 
     def test_priv_revoke_read(self):
         """Test ability to revoke read privs"""
-
         self.create_all_tables()
 
         try:
@@ -209,7 +205,6 @@ class TestGDCPostgresAdmin(unittest.TestCase):
 
     def test_priv_revoke_write(self):
         """Test ability to revoke read/write privs"""
-
         self.create_all_tables()
 
         try:

--- a/test/test_gdc_postgres_admin.py
+++ b/test/test_gdc_postgres_admin.py
@@ -33,7 +33,6 @@ class TestGDCPostgresAdmin(unittest.TestCase):
         database,
     ]
 
-    # TODO: it looks like the graph and root_con_str were to be done by the owner of the database.
     g = PsqlGraphDriver(host, user, password, database)
 
     root_con_str = "postgres://{user}:{pwd}@{host}/{db}".format(

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     no_proxy=localhost,postgres
 extras = dev
 commands =
-    python -m pytest -lv --cov gdcdatamodel --cov-report xml --cov-report html --junit-xml report.xml {posargs}
+    python -m pytest -lvx --cov gdcdatamodel --cov-report xml --cov-report html --junit-xml report.xml {posargs}
 
 [testenv:publish]
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-# TODO: need to upgrade gdc_ng_models to remove distutils to support python 3.12 & 3.13
+# DEV-3572 TODO: upgrade gdc_ng_models to remove distutils to support python 3.12 & 3.13
 envlist = py3{9,10,11}
 skip_missing_interpreters = True
 isolated_build = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-# DEV-3572 TODO: upgrade gdc_ng_models to remove distutils to support python 3.12 & 3.13
-envlist = py3{9,10,11}
+envlist = py3{9,10,11,12,13}
 
 [pytest]
 testpaths =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py3{9,10,11,12,13}
+# TODO: need to upgrade gdc_ng_models to remove distutils to support python 3.12 & 3.13
+envlist = py3{9,10,11}
 skip_missing_interpreters = True
 isolated_build = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py39,py310,py311,py312,py313
+envlist = py3{9,10,11,12,13}
+skip_missing_interpreters = True
+isolated_build = True
 
 [pytest]
 testpaths =
@@ -11,10 +13,9 @@ passenv =
 setenv =
     NO_PROXY=localhost,postgres
     no_proxy=localhost,postgres
-extras =
-    dev
+extras = dev
 commands =
-    pytest -lvx --cov gdcdatamodel --cov-report term --cov-report xml --cov-report html --junit-xml test-reports/results.xml {posargs}
+    pythom -m pytest -lvx --cov gdcdatamodel --cov-report term --cov-report xml --cov-report html --junit-xml test-reports/results.xml {posargs}
 
 [testenv:coverage]
 passenv = CODACY_PROJECT_TOKEN

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{9,10,11,12,13}
+envlist = py3{9,10,11,12}
 
 [pytest]
 testpaths =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 # DEV-3572 TODO: upgrade gdc_ng_models to remove distutils to support python 3.12 & 3.13
 envlist = py3{9,10,11}
-skip_missing_interpreters = True
-isolated_build = True
 
 [pytest]
 testpaths =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
 extras =
     dev
 commands =
-    pytest -lv --cov gdcdatamodel --cov-report term --cov-report xml --cov-report html --junit-xml test-reports/results.xml {posargs}
+    pytest -lvx --cov gdcdatamodel --cov-report term --cov-report xml --cov-report html --junit-xml test-reports/results.xml {posargs}
 
 [testenv:coverage]
 passenv = CODACY_PROJECT_TOKEN

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     no_proxy=localhost,postgres
 extras = dev
 commands =
-    pythom -m pytest -lvx --cov gdcdatamodel --cov-report term --cov-report xml --cov-report html --junit-xml test-reports/results.xml {posargs}
+    python -m pytest -lvx --cov gdcdatamodel --cov-report term --cov-report xml --cov-report html --junit-xml test-reports/results.xml {posargs}
 
 [testenv:coverage]
 passenv = CODACY_PROJECT_TOKEN

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,7 @@ setenv =
     no_proxy=localhost,postgres
 extras = dev
 commands =
-    python -m pytest -lvx --cov gdcdatamodel --cov-report term --cov-report xml --cov-report html --junit-xml test-reports/results.xml {posargs}
-
-[testenv:coverage]
-passenv = CODACY_PROJECT_TOKEN
-deps =
-    requests
-    codacy-coverage
-commands = python-codacy-coverage -r coverage.xml
+    python -m pytest -lv --cov-report xml --cov-report html --junit-xml report.xml {posargs}
 
 [testenv:publish]
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     no_proxy=localhost,postgres
 extras = dev
 commands =
-    python -m pytest -lv --cov-report xml --cov-report html --junit-xml report.xml {posargs}
+    python -m pytest -lv --cov gdcdatamodel --cov-report xml --cov-report html --junit-xml report.xml {posargs}
 
 [testenv:publish]
 changedir =


### PR DESCRIPTION
- Updates the gitlab-ci.yml to latest
- Adds pre-commit hooks (except for ruff that is going to be a big deal and will be its own PR). It did reformat some things.
- Moved test database creation into the tests so it will work in all environments without external setup.
- FIPS md5 handling